### PR TITLE
fix: long notes hid the hadith text, plus mobile header and card layout cleanup

### DIFF
--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -2135,12 +2135,73 @@ main.container::before {
     font-variant-ligatures: common-ligatures contextual;
 }
 
+/* Scholarly apparatus: a cool teal panel with a cyan-green rule, so notes
+   read as marginalia rather than as a continuation of the narration itself.
+   The card grows to fit them, so nothing here competes for the text's height. */
 .hadith-notes {
-    font-size: 0.92rem;
+    font-size: 0.88rem;
     line-height: 1.7;
     color: var(--text-secondary);
-    padding-top: 0.75rem;
-    border-top: 1px solid var(--border);
+    padding: 0.8rem 1rem 0.85rem;
+    background: #effaf8;
+    border: 1px solid rgba(13, 148, 136, 0.22);
+    border-left: 3px solid #0d9488;
+    border-radius: var(--radius-sm);
+    display: flex;
+    flex-direction: column;
+}
+
+.hadith-notes__head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
+}
+
+.hadith-notes__head::after {
+    content: "";
+    flex: 1 1 auto;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(13, 148, 136, 0.35), transparent);
+}
+
+.hadith-notes__label {
+    font-size: 0.64rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: #0f766e;
+}
+
+/* Preview state: show the opening lines and fade them out, so there is
+   visibly more to read rather than a bare toggle. */
+.hadith-notes__body--clamped {
+    max-height: 6.2rem;
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(180deg, #000 58%, transparent 100%);
+    mask-image: linear-gradient(180deg, #000 58%, transparent 100%);
+}
+
+.hadith-notes__toggle {
+    align-self: flex-start;
+    margin-top: 0.45rem;
+    border: 1px solid rgba(13, 148, 136, 0.4);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.8);
+    color: #0f766e;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 0.22rem 0.72rem;
+    cursor: pointer;
+    transition: all 150ms ease;
+}
+
+.hadith-notes__toggle:hover {
+    background: #fff;
+    border-color: #0d9488;
+    color: #0b5f59;
 }
 
 .hadith-content .highlight,
@@ -5918,6 +5979,9 @@ main.container {
 
 .hadith-card {
     --hadith-content-min-height: 0px;
+    /* The card grows to fit: expanding the notes or opening a related /
+       tafsir panel must not steal height from the narration text. */
+    --hadith-card-max-height: none;
     --hadith-reading-max-height: min(58dvh, 44rem);
     --hadith-reading-mobile-max-height: min(42dvh, 24rem);
     --hadith-inline-max-height: min(32dvh, 22rem);
@@ -5939,7 +6003,6 @@ main.container {
 .hadith-card--similar,
 .hadith-card--quran {
     --hadith-content-min-height: min(56rem, 86dvh);
-    --hadith-reading-max-height: min(31dvh, 20rem);
     --hadith-inline-max-height: min(35dvh, 24rem);
     --hadith-inline-snippet-max-height: min(40dvh, 28rem);
 }
@@ -5957,7 +6020,7 @@ main.container {
     display: grid;
     grid-template-columns: minmax(248px, var(--hadith-sidecar-width, 304px)) 18px minmax(0, 3fr);
     align-items: start;
-    max-height: min(90dvh, 60rem);
+    max-height: var(--hadith-card-max-height);
     overflow: hidden;
 }
 
@@ -5990,7 +6053,7 @@ main.container {
     padding: 0;
     min-height: 100%;
     align-self: stretch;
-    max-height: min(90dvh, 60rem);
+    max-height: var(--hadith-card-max-height);
     grid-column: 1;
     grid-row: 1 / span 2;
 }
@@ -6002,7 +6065,7 @@ main.container {
     padding: 2.45rem 2.15rem 1.8rem 1.85rem !important;
     grid-column: 3;
     grid-row: 1;
-    max-height: min(90dvh, 60rem);
+    max-height: var(--hadith-card-max-height);
     overflow-y: auto;
 }
 
@@ -6777,6 +6840,11 @@ body.is-resizing-sidecar * {
 
 .hadith-reading-scroll {
     max-height: var(--hadith-reading-max-height);
+    /* overflow-y:auto makes the automatic minimum size resolve to 0, which
+       previously let this pane absorb the whole card's shrinkage until the
+       narration vanished. It is the primary content, so it never gives up
+       height: the card grows instead. */
+    flex: 0 0 auto;
     overflow-y: auto;
     overflow-x: hidden;
     padding-right: 0.35rem;
@@ -7764,9 +7832,13 @@ body.is-resizing-sidecar * {
         max-height: none;
     }
 
-    /* On mobile, hide main hadith text when similar/quran tab is active */
+    /* On mobile, hide main hadith text when similar/quran tab is active.
+       The notes go with it: they annotate the narration, so leaving them
+       behind shows a gloss for text that is no longer on screen. */
     .hadith-content.sidecar-active--similar .hadith-reading-scroll,
-    .hadith-content.sidecar-active--quran .hadith-reading-scroll {
+    .hadith-content.sidecar-active--quran .hadith-reading-scroll,
+    .hadith-content.sidecar-active--similar .hadith-notes,
+    .hadith-content.sidecar-active--quran .hadith-notes {
         display: none;
     }
     .hadith-content.sidecar-active--similar .hadith-card__ornament,

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -6326,8 +6326,8 @@ body.is-resizing-sidecar * {
     top: auto;
     right: auto;
     left: 50%;
-    bottom: 0.3rem;
-    margin-left: 0.55rem;
+    bottom: 0.1rem;
+    margin-left: 0;
     min-width: 1.05rem;
     height: 1.05rem;
     padding: 0 0.18rem;
@@ -7982,8 +7982,7 @@ body.is-resizing-sidecar * {
     }
 
     .hadith-sidecar__rail-badge {
-        bottom: 0.22rem;
-        margin-left: 0.5rem;
+        bottom: 0.08rem;
     }
 
     .hadith-sidecar__panel {

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -4615,6 +4615,10 @@ code.welcome {
    RESPONSIVE
    ======================================================================== */
 @media (max-width: 992px) {
+    /* Deliberately class-only: #queryBar's id-specificity flex wins here, and
+       letting this rule apply pushes the bar onto its own row on tablets,
+       growing the sticky nav from 98px to 154px. Only the <=768px block below
+       is raised to id specificity. */
     .navbar-search {
         flex: 1 1 100%;
         max-width: 100%;
@@ -4648,10 +4652,27 @@ code.welcome {
         align-content: flex-start;
         gap: 0.4rem;
     }
+    /* Same id-specificity trap as above: without #queryBar the flex shorthand
+       is dropped and the bar wraps on a 390px phone but not a 414px one. */
+    #queryBar,
     .navbar-search {
         order: 1;
         width: 100%;
         flex: 0 0 auto;
+    }
+
+    /* Partially persistent header (NN/g). The two-row nav is the right shape
+       for a query with filter pills, but it is sticky, so on a 390x844 phone
+       it would cost 116px - 14% of the viewport - for the entire read. Stow it
+       while the reader scrolls down and return it the moment they scroll up,
+       so the cost is paid only when the search is actually wanted.
+       translateY keeps this off the layout path: no reflow, no CLS. */
+    .site-nav {
+        transition: transform 220ms ease;
+    }
+
+    .site-nav--stowed {
+        transform: translateY(-100%);
     }
     .menu-context-row {
         order: 0;
@@ -4926,6 +4947,12 @@ body::after {
         linear-gradient(90deg, rgba(16, 35, 63, 0.035) 1px, transparent 1px);
     background-size: 36px 36px;
     mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0.08));
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .site-nav {
+        transition: none !important;
+    }
 }
 
 .site-nav {

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -6876,15 +6876,53 @@ body.is-resizing-sidecar * {
     min-height: 0;
 }
 
-/* No inner scroll on the narration. The card grows to fit its content, so
-   capping this pane bought nothing and only created a nested scroll region
-   that traps the wheel and makes the page feel like it sticks. One scrollbar,
-   on the page. */
+/* No inner scroll on the narration: a scroll region inside the page scroll
+   traps the wheel and makes the page feel like it sticks. Long narrations are
+   clamped with an explicit control instead, so results stay scannable without
+   forcing the reader to scroll a whole hadith to reach the next one. */
 .hadith-reading-scroll {
     flex: 0 0 auto;
     overflow: visible;
     padding-right: 0.35rem;
     margin-top: -15px;
+}
+
+.hadith-reading-scroll--clamped {
+    max-height: 20rem;
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(180deg, #000 76%, transparent 100%);
+    mask-image: linear-gradient(180deg, #000 76%, transparent 100%);
+}
+
+.hadith-reading-toggle {
+    position: relative;
+    align-self: flex-start;
+    flex: 0 0 auto;
+    margin-top: 0.5rem;
+    border: 1px solid rgba(16, 35, 63, 0.18);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--primary-lighter);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 0.28rem 0.85rem;
+    cursor: pointer;
+    transition: all 150ms ease;
+}
+
+/* Keep the visual pill small but meet the 44px touch target. */
+.hadith-reading-toggle::after {
+    content: "";
+    position: absolute;
+    inset: -8px -8px -12px -8px;
+}
+
+.hadith-reading-toggle:hover {
+    background: #fff;
+    border-color: var(--primary-lighter);
+    color: var(--primary);
 }
 
 .hadith-reading-scroll::-webkit-scrollbar,

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -4651,6 +4651,11 @@ code.welcome {
 
 @media (max-width: 768px) {
     .brand-logo--full { height: 38px; }
+    .brand-logo--icon { height: 30px; }
+
+    .site-nav { padding-top: 0.45rem; padding-bottom: 0.5rem; }
+
+    .navbar-brand { align-self: center; }
 
     .profile-chip { padding-right: 0.45rem !important; }
     .profile-chip__meta { max-width: 6rem; }
@@ -4663,13 +4668,22 @@ code.welcome {
         align-content: flex-start;
         gap: 0.4rem;
     }
-    /* Same id-specificity trap as above: without #queryBar the flex shorthand
-       is dropped and the bar wraps on a 390px phone but not a 414px one. */
+    /* One row: the search sits between the logo and the menu rather than
+       below them, which removes the dead gap across the middle of the header.
+       Viable now that the term pills stay on a single line and scroll
+       sideways instead of wrapping the bar to three rows.
+       #queryBar is included because it is this same element and sets flex with
+       id specificity, so the class selector alone silently loses here. */
     #queryBar,
     .navbar-search {
-        order: 1;
-        width: 100%;
-        flex: 0 0 auto;
+        order: 0;
+        width: auto;
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    .navbar-top {
+        flex-wrap: nowrap !important;
     }
 
     /* Partially persistent header (NN/g). The two-row nav is the right shape
@@ -9571,7 +9585,7 @@ body.is-search-mode .site-nav .search-entry-shell {
     :root {
         --search-shell-height: 44px;
         --search-action-height: 34px;
-        --search-entry-side-pad: 5.5rem;
+        --search-entry-side-pad: 3rem;
     }
 
     .search-entry-shell {
@@ -9664,24 +9678,66 @@ body.is-search-mode .site-nav .search-entry-shell {
         right: 4px;
     }
 
+    /* Pin the search row to a single compact line. Inner tom-select wrappers
+       were padding the shell out to 58px around a 26px pill. */
     .site-nav .search-entry-shell {
         overflow: hidden;
-        max-height: 88px;
+        height: var(--search-shell-height);
+        min-height: var(--search-shell-height);
+        max-height: var(--search-shell-height);
     }
 
+    .site-nav .search-entry-shell .ts-wrapper,
+    .site-nav .search-entry-shell .navbar-search__input {
+        height: 100%;
+        min-height: 0;
+    }
+
+    .site-nav .search-entry-shell .ts-control .item {
+        min-height: 22px !important;
+        padding: 2px 8px !important;
+        font-size: 0.78rem !important;
+    }
+
+    /* The strip scrolls under the search button, so fade it out just before
+       the button instead of letting a term be sliced mid-word. */
+    .site-nav .search-entry-shell::after {
+        content: "";
+        position: absolute;
+        top: 1px;
+        bottom: 1px;
+        right: var(--search-entry-side-pad);
+        width: 1.4rem;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.98));
+        pointer-events: none;
+        z-index: 2;
+    }
+
+    /* Keep the terms on one line and let them scroll sideways. Wrapping made
+       the bar grow to two and three rows, so the pills took half the height
+       of the header. */
     .site-nav .search-entry-shell .ts-control,
     .site-nav .ts-wrapper .ts-control,
     .site-nav .navbar-search .ts-control {
         background: transparent !important;
         border: 0 !important;
         box-shadow: none !important;
-        max-height: 88px;
-        overflow-y: auto;
+        flex-wrap: nowrap !important;
+        min-height: 0 !important;
+        max-height: 100% !important;
+        overflow-x: auto;
+        overflow-y: hidden;
+        scrollbar-width: none;
         -webkit-overflow-scrolling: touch;
     }
 
+    .site-nav .search-entry-shell .ts-control::-webkit-scrollbar {
+        display: none;
+    }
+
     .site-nav .search-entry-shell .ts-control .item {
-        max-width: 120px;
+        flex: 0 0 auto;
+        max-width: 11rem;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -9940,5 +9996,99 @@ body.is-search-mode .site-nav .search-entry-shell {
 
     .hadith-divider__motif {
         font-size: 0.94rem;
+    }
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════
+   COMPACT HEADER  (phones portrait and landscape, small tablets)
+   A landscape phone is ~844px wide, above the 768px phone breakpoint, so it
+   was still getting the tall two-row header - 120px out of a 390px-tall
+   viewport. Apply the compact single-row header everywhere below the desktop
+   layout instead of by device width alone.
+   ═══════════════════════════════════════════════════════════════════════ */
+@media (max-width: 992px) {
+    :root {
+        --search-shell-height: 44px;
+        --search-action-height: 34px;
+        --search-entry-side-pad: 3rem;
+    }
+
+    .site-nav {
+        padding-top: 0.45rem;
+        padding-bottom: 0.5rem;
+    }
+
+    .brand-logo--icon { height: 30px; }
+    .navbar-brand { align-self: center; }
+
+    .navbar-top {
+        flex-wrap: nowrap !important;
+        align-items: center;
+    }
+
+    /* Search sits between the logo and the menu rather than below them. */
+    #queryBar,
+    .navbar-search {
+        order: 0;
+        width: auto;
+        flex: 1 1 auto;
+        min-width: 0;
+        max-width: none;
+    }
+
+    .site-nav .search-entry-shell {
+        position: relative;
+        overflow: hidden;
+        height: var(--search-shell-height);
+        min-height: var(--search-shell-height);
+        max-height: var(--search-shell-height);
+    }
+
+    .site-nav .search-entry-shell .ts-wrapper,
+    .site-nav .search-entry-shell .navbar-search__input {
+        height: 100%;
+        min-height: 0;
+    }
+
+    /* Terms stay on one line and scroll sideways. */
+    .site-nav .search-entry-shell .ts-control,
+    .site-nav .ts-wrapper .ts-control,
+    .site-nav .navbar-search .ts-control {
+        flex-wrap: nowrap !important;
+        min-height: 0 !important;
+        max-height: 100% !important;
+        overflow-x: auto;
+        overflow-y: hidden;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .site-nav .search-entry-shell .ts-control::-webkit-scrollbar {
+        display: none;
+    }
+
+    .site-nav .search-entry-shell .ts-control .item {
+        flex: 0 0 auto;
+        min-height: 22px !important;
+        padding: 2px 8px !important;
+        font-size: 0.78rem !important;
+        max-width: 11rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    /* Fade the strip out before the search button rather than slicing a term. */
+    .site-nav .search-entry-shell::after {
+        content: "";
+        position: absolute;
+        top: 1px;
+        bottom: 1px;
+        right: var(--search-entry-side-pad);
+        width: 1.4rem;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.98));
+        pointer-events: none;
+        z-index: 2;
     }
 }

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -6886,14 +6886,9 @@ body.is-resizing-sidecar * {
     overflow-y: auto;
     overflow-x: hidden;
     padding-right: 0.35rem;
-    overscroll-behavior-y: contain;
+    /* Default (auto) chaining on purpose: reaching the end of this pane must
+       continue scrolling the page, not dead-end. */
     margin-top: -15px;
-}
-
-@media (max-width: 768px) {
-    .hadith-reading-scroll {
-        overscroll-behavior-y: auto;
-    }
 }
 
 .hadith-reading-scroll::-webkit-scrollbar,
@@ -7016,13 +7011,6 @@ body.is-resizing-sidecar * {
     overflow-y: auto;
     overflow-x: hidden;
     padding-right: 0.3rem;
-    overscroll-behavior-y: contain;
-}
-
-@media (max-width: 768px) {
-    .hadith-inline-context__scroll {
-        overscroll-behavior-y: auto;
-    }
 }
 
 .hadith-inline-context__panel {
@@ -7064,13 +7052,6 @@ body.is-resizing-sidecar * {
     max-height: var(--hadith-inline-snippet-max-height);
     overflow-y: auto;
     padding-right: 0.25rem;
-    overscroll-behavior-y: contain;
-}
-
-@media (max-width: 768px) {
-    .hadith-inline-context__snippets {
-        overscroll-behavior-y: auto;
-    }
 }
 
 .hadith-inline-context__body .similar-full-english {

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -2183,6 +2183,7 @@ main.container::before {
 }
 
 .hadith-notes__toggle {
+    position: relative;
     align-self: flex-start;
     margin-top: 0.45rem;
     border: 1px solid rgba(13, 148, 136, 0.4);
@@ -2196,6 +2197,16 @@ main.container::before {
     padding: 0.22rem 0.72rem;
     cursor: pointer;
     transition: all 150ms ease;
+}
+
+/* The pill reads better small, but 28px is under the 44px minimum touch
+   target, so extend the hit area past the visual bounds instead of inflating
+   it. The upward 6px sits inside the existing margin, so it does not steal
+   taps from the notes text above. */
+.hadith-notes__toggle::after {
+    content: "";
+    position: absolute;
+    inset: -7px -8px -13px -8px;
 }
 
 .hadith-notes__toggle:hover {

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -6894,34 +6894,33 @@ body.is-resizing-sidecar * {
     mask-image: linear-gradient(180deg, #000 76%, transparent 100%);
 }
 
-/* Revealing the narration is the card's primary action, so it carries the
-   brand gold rather than the generic link blue used elsewhere, and an icon
-   so it reads as a control at a glance. */
+/* Revealing the narration is the card's primary action: solid navy so it is
+   unmissable against the light card, centred under the text it reveals, and
+   squared off so it reads as a control rather than a tag. */
 .hadith-reading-toggle {
     position: relative;
-    align-self: flex-start;
+    align-self: center;
     flex: 0 0 auto;
     display: inline-flex;
     align-items: center;
-    gap: 0.45rem;
-    margin-top: 0.6rem;
-    border: 1px solid rgba(199, 154, 59, 0.55);
-    border-radius: 999px;
-    background: linear-gradient(180deg, #fdf3da, var(--gold-bg));
-    color: #7d5c15;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    border: 1px solid var(--primary);
+    border-radius: 6px;
+    background: var(--primary);
+    color: #ffffff;
     font-size: 0.72rem;
-    font-weight: 800;
-    letter-spacing: 0.07em;
+    font-weight: 700;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    padding: 0.34rem 0.95rem;
-    box-shadow: 0 1px 2px rgba(159, 118, 37, 0.14);
+    padding: 0.46rem 1.15rem;
+    box-shadow: 0 2px 5px rgba(16, 35, 63, 0.22);
     cursor: pointer;
     transition: all 150ms ease;
 }
 
 .hadith-reading-toggle .fa {
-    font-size: 0.78rem;
-    opacity: 0.85;
+    font-size: 0.76rem;
 }
 
 /* Keep the visual pill small but meet the 44px touch target. */
@@ -6932,10 +6931,10 @@ body.is-resizing-sidecar * {
 }
 
 .hadith-reading-toggle:hover {
-    background: linear-gradient(180deg, #fbead0, #fdf3da);
-    border-color: var(--gold);
-    color: #63480d;
-    box-shadow: 0 2px 5px rgba(159, 118, 37, 0.2);
+    background: var(--primary-lighter);
+    border-color: var(--primary-lighter);
+    color: #ffffff;
+    box-shadow: 0 3px 9px rgba(16, 35, 63, 0.3);
 }
 
 .hadith-reading-scroll::-webkit-scrollbar,

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -6334,13 +6334,16 @@ body.is-resizing-sidecar * {
 /* Anchored beside the icon, not to the tab's corner. The tab is a column with
    the label above the icon, so a corner-pinned badge ends up diagonally
    opposite the icon it counts for - most visible in landscape, where the tabs
-   are widest. 50% + offset tracks the centred icon at any tab width. */
+   are widest. Offsetting from 50% tracks the centred icon at any tab width. */
 .hadith-sidecar__rail-badge {
     position: absolute;
     top: auto;
     right: auto;
-    left: 50%;
-    bottom: 0.1rem;
+    /* Top-right of the icon, the conventional place for a count. Nudged down
+       a few px because the tab is a column with the label directly above the
+       icon, and a badge centred on the corner would run into it. */
+    left: calc(50% + 0.125rem);
+    bottom: 0.9rem;
     margin-left: 0;
     min-width: 1.05rem;
     height: 1.05rem;
@@ -7000,24 +7003,28 @@ body.is-resizing-sidecar * {
     line-height: 1.72 !important;
 }
 
+/* This panel replaces the reader's view when they pick a related hadith or a
+   tafsir source, so it has to announce itself. It was #f5f8fd against a card
+   that is already near-white, which made the switch easy to miss. Give it a
+   warm parchment surface with a gold rule. Blue is no use here - the nav,
+   sidecar, tag pills and card accents are all navy already - so warm is the
+   only direction that actually separates it, and it suits the manuscript
+   identity. Teal for apparatus on this hadith, parchment for other corpora. */
 .hadith-inline-context {
-    margin-top: 0.15rem;
+    margin-top: 0.55rem;
     padding: 0.95rem 0.98rem 1rem;
-    border-radius: 18px;
-    border: 1px solid rgba(16, 35, 63, 0.1);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(199, 154, 59, 0.42);
+    border-left: 3px solid var(--gold);
+    box-shadow: 0 3px 12px rgba(120, 90, 30, 0.12);
 }
 
 .hadith-inline-context--similar {
-    background:
-        linear-gradient(180deg, rgba(28, 57, 101, 0.08), rgba(247, 225, 166, 0.05)),
-        #f5f8fd;
+    background: linear-gradient(180deg, #fbf1dc, #fdf8ec);
 }
 
 .hadith-inline-context--quran {
-    background:
-        linear-gradient(180deg, rgba(28, 57, 101, 0.08), rgba(247, 225, 166, 0.05)),
-        #f5f8fd;
+    background: linear-gradient(180deg, #fbf1dc, #fdf8ec);
 }
 
 .hadith-inline-context__head {
@@ -7993,10 +8000,6 @@ body.is-resizing-sidecar * {
         font-size: 0.67rem;
         font-weight: 700;
         line-height: 1;
-    }
-
-    .hadith-sidecar__rail-badge {
-        bottom: 0.08rem;
     }
 
     .hadith-sidecar__panel {

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -8871,15 +8871,24 @@ body.is-search-mode .site-nav .navbar-search__input {
 }
 
 .site-nav .search-entry-shell {
-    background: rgba(255, 255, 255, 0.98);
-    border-color: rgba(79, 88, 101, 0.5);
+    /* Slightly translucent so the navy tints it, instead of a pure-white slab
+       punched out of the header. Still a filled field, so it keeps reading as
+       an input. */
+    background: rgba(255, 255, 255, 0.88);
+    border-color: rgba(255, 255, 255, 0.34);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
     margin-top: 0;
 }
 
-.home-search .search-entry-shell,
-body.is-search-mode .site-nav .search-entry-shell {
+.home-search .search-entry-shell {
     background: rgba(255, 255, 255, 0.98);
     border: 1px solid rgba(79, 88, 101, 0.5);
+    border-radius: 11px;
+}
+
+body.is-search-mode .site-nav .search-entry-shell {
+    background: rgba(255, 255, 255, 0.88);
+    border: 1px solid rgba(255, 255, 255, 0.34);
     border-radius: 11px;
 }
 
@@ -9708,7 +9717,7 @@ body.is-search-mode .site-nav .search-entry-shell {
         bottom: 1px;
         right: var(--search-entry-side-pad);
         width: 1.4rem;
-        background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.98));
+        background: linear-gradient(90deg, rgba(225, 226, 228, 0), rgb(225, 226, 228));
         pointer-events: none;
         z-index: 2;
     }
@@ -10087,7 +10096,7 @@ body.is-search-mode .site-nav .search-entry-shell {
         bottom: 1px;
         right: var(--search-entry-side-pad);
         width: 1.4rem;
-        background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.98));
+        background: linear-gradient(90deg, rgba(225, 226, 228, 0), rgb(225, 226, 228));
         pointer-events: none;
         z-index: 2;
     }

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -6876,18 +6876,14 @@ body.is-resizing-sidecar * {
     min-height: 0;
 }
 
+/* No inner scroll on the narration. The card grows to fit its content, so
+   capping this pane bought nothing and only created a nested scroll region
+   that traps the wheel and makes the page feel like it sticks. One scrollbar,
+   on the page. */
 .hadith-reading-scroll {
-    max-height: var(--hadith-reading-max-height);
-    /* overflow-y:auto makes the automatic minimum size resolve to 0, which
-       previously let this pane absorb the whole card's shrinkage until the
-       narration vanished. It is the primary content, so it never gives up
-       height: the card grows instead. */
     flex: 0 0 auto;
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow: visible;
     padding-right: 0.35rem;
-    /* Default (auto) chaining on purpose: reaching the end of this pane must
-       continue scrolling the page, not dead-end. */
     margin-top: -15px;
 }
 
@@ -8975,14 +8971,20 @@ body.is-search-mode .site-nav .search-entry-shell {
 .site-nav .ts-control .item .remove {
     color: #173964 !important;
     opacity: 0.6 !important;
-    margin-left: 7px !important;
-    min-width: 16px !important;
-    font-size: 0.82rem !important;
+    /* Sits at the pill's top-right rather than centred on the text baseline.
+       Kept in normal flow, so it always reserves its own width and can never
+       overlap the label. */
+    align-self: flex-start !important;
+    margin-left: 6px !important;
+    margin-top: -2px !important;
+    min-width: 12px !important;
+    line-height: 1 !important;
+    font-size: 0.78rem !important;
     background: transparent !important;
     border-left: 0 !important;
     box-shadow: none !important;
     border-radius: 0 !important;
-    padding: 0 !important;
+    padding: 2px 4px 0 0 !important;
 }
 
 .site-nav .ts-control .item .remove:hover {
@@ -8994,14 +8996,20 @@ body.is-search-mode .site-nav .search-entry-shell {
 .navbar-search .ts-control .item .remove {
     color: #173964 !important;
     opacity: 0.6 !important;
-    margin-left: 7px !important;
-    min-width: 16px !important;
-    font-size: 0.82rem !important;
+    /* Sits at the pill's top-right rather than centred on the text baseline.
+       Kept in normal flow, so it always reserves its own width and can never
+       overlap the label. */
+    align-self: flex-start !important;
+    margin-left: 6px !important;
+    margin-top: -2px !important;
+    min-width: 12px !important;
+    line-height: 1 !important;
+    font-size: 0.78rem !important;
     background: transparent !important;
     border-left: 0 !important;
     box-shadow: none !important;
     border-radius: 0 !important;
-    padding: 0 !important;
+    padding: 2px 4px 0 0 !important;
 }
 
 .home-search .ts-control .item .remove:hover,

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -6894,22 +6894,34 @@ body.is-resizing-sidecar * {
     mask-image: linear-gradient(180deg, #000 76%, transparent 100%);
 }
 
+/* Revealing the narration is the card's primary action, so it carries the
+   brand gold rather than the generic link blue used elsewhere, and an icon
+   so it reads as a control at a glance. */
 .hadith-reading-toggle {
     position: relative;
     align-self: flex-start;
     flex: 0 0 auto;
-    margin-top: 0.5rem;
-    border: 1px solid rgba(16, 35, 63, 0.18);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 0.6rem;
+    border: 1px solid rgba(199, 154, 59, 0.55);
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.9);
-    color: var(--primary-lighter);
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    background: linear-gradient(180deg, #fdf3da, var(--gold-bg));
+    color: #7d5c15;
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.07em;
     text-transform: uppercase;
-    padding: 0.28rem 0.85rem;
+    padding: 0.34rem 0.95rem;
+    box-shadow: 0 1px 2px rgba(159, 118, 37, 0.14);
     cursor: pointer;
     transition: all 150ms ease;
+}
+
+.hadith-reading-toggle .fa {
+    font-size: 0.78rem;
+    opacity: 0.85;
 }
 
 /* Keep the visual pill small but meet the 44px touch target. */
@@ -6920,9 +6932,10 @@ body.is-resizing-sidecar * {
 }
 
 .hadith-reading-toggle:hover {
-    background: #fff;
-    border-color: var(--primary-lighter);
-    color: var(--primary);
+    background: linear-gradient(180deg, #fbead0, #fdf3da);
+    border-color: var(--gold);
+    color: #63480d;
+    box-shadow: 0 2px 5px rgba(159, 118, 37, 0.2);
 }
 
 .hadith-reading-scroll::-webkit-scrollbar,

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -6020,8 +6020,6 @@ main.container {
     /* The card grows to fit: expanding the notes or opening a related /
        tafsir panel must not steal height from the narration text. */
     --hadith-card-max-height: none;
-    --hadith-reading-max-height: min(58dvh, 44rem);
-    --hadith-reading-mobile-max-height: min(42dvh, 24rem);
     --hadith-inline-max-height: min(32dvh, 22rem);
     --hadith-inline-snippet-max-height: min(36dvh, 24rem);
     border: 1px solid #d0d4da !important;
@@ -6035,7 +6033,6 @@ main.container {
 
 .hadith-card--metadata {
     --hadith-content-min-height: 0px;
-    --hadith-reading-max-height: min(72dvh, 52rem);
 }
 
 .hadith-card--similar,
@@ -6320,10 +6317,17 @@ body.is-resizing-sidecar * {
     opacity: 0.6;
 }
 
+/* Anchored beside the icon, not to the tab's corner. The tab is a column with
+   the label above the icon, so a corner-pinned badge ends up diagonally
+   opposite the icon it counts for - most visible in landscape, where the tabs
+   are widest. 50% + offset tracks the centred icon at any tab width. */
 .hadith-sidecar__rail-badge {
     position: absolute;
-    top: 0.35rem;
-    right: 0.35rem;
+    top: auto;
+    right: auto;
+    left: 50%;
+    bottom: 0.3rem;
+    margin-left: 0.55rem;
     min-width: 1.05rem;
     height: 1.05rem;
     padding: 0 0.18rem;
@@ -7796,7 +7800,6 @@ body.is-resizing-sidecar * {
 
     .hadith-card {
         --hadith-content-min-height: auto;
-        --hadith-reading-max-height: var(--hadith-reading-mobile-max-height);
         --hadith-inline-max-height: min(28dvh, 18rem);
         --hadith-inline-snippet-max-height: min(31dvh, 18rem);
     }
@@ -7979,8 +7982,8 @@ body.is-resizing-sidecar * {
     }
 
     .hadith-sidecar__rail-badge {
-        top: 0.25rem;
-        right: 0.25rem;
+        bottom: 0.22rem;
+        margin-left: 0.5rem;
     }
 
     .hadith-sidecar__panel {
@@ -8056,8 +8059,10 @@ body.is-resizing-sidecar * {
         width: 100%;
     }
 
+    /* No max-height here: the pane no longer scrolls, so a cap would let the
+       narration spill out of the card and render over the tags. Long
+       narrations are bounded by the --clamped modifier instead. */
     .hadith-reading-scroll {
-        max-height: var(--hadith-reading-mobile-max-height);
         padding-right: 0.2rem;
     }
 

--- a/src/main/resources/static/js/rewayaat.js
+++ b/src/main/resources/static/js/rewayaat.js
@@ -6266,7 +6266,32 @@ function setupVue(query, page, sortFields) {
             },
             toggleNarrationExpand: function(narration) {
                 var key = this.narrationExpandKey(narration);
-                Vue.set(this.narrationExpandedKeys, key, !this.narrationExpandedKeys[key]);
+                var expanding = !this.narrationExpandedKeys[key];
+                var domId = this.narrationDomId(narration);
+                var card = domId ? document.getElementById(domId) : null;
+                // Collapsing removes content above the button, so the page
+                // shrinks underneath the reader and the hadith ends up above
+                // the viewport. Pin the button where it already is on screen so
+                // the card stays put. Expanding needs no correction: the card's
+                // top does not move, the text simply grows downward.
+                var button = card ? card.querySelector('.hadith-reading-toggle') : null;
+                var anchorBefore = (!expanding && button)
+                    ? button.getBoundingClientRect().top
+                    : null;
+                Vue.set(this.narrationExpandedKeys, key, expanding);
+                if (anchorBefore === null) {
+                    return;
+                }
+                this.$nextTick(function() {
+                    var after = card.querySelector('.hadith-reading-toggle');
+                    if (!after) {
+                        return;
+                    }
+                    var delta = after.getBoundingClientRect().top - anchorBefore;
+                    if (Math.abs(delta) > 1) {
+                        window.scrollBy(0, delta);
+                    }
+                });
             },
             notesExpandKey: function(narration) {
                 return (narration._id || narration.id || '') + '-notes';

--- a/src/main/resources/static/js/rewayaat.js
+++ b/src/main/resources/static/js/rewayaat.js
@@ -916,6 +916,70 @@ function initAuthUI() {
     }
 }
 
+// Partially persistent header. On phones the nav is two rows (~116px) so the
+// search field has room for filter pills, but it is sticky, so that height is
+// spent on every screen of reading. Stow it on scroll down, return it on scroll
+// up, at the top, and at the bottom of the page.
+function initStowingNav() {
+    var nav = document.querySelector('.site-nav');
+    if (!nav || !window.matchMedia || !window.requestAnimationFrame) {
+        return;
+    }
+    var mobile = window.matchMedia('(max-width: 768px)');
+    var lastY = Math.max(0, window.pageYOffset || 0);
+    var queued = false;
+    // Leave the header alone until the reader is clear of it, and ignore
+    // sub-pixel jitter and iOS rubber-banding.
+    var STOW_BELOW = 140;
+    var MIN_DELTA = 6;
+
+    function show() {
+        nav.classList.remove('site-nav--stowed');
+    }
+
+    function update() {
+        queued = false;
+        var y = Math.max(0, window.pageYOffset || 0);
+        var delta = y - lastY;
+        lastY = y;
+        // Desktop, or the reader is typing in the bar we would be hiding.
+        if (!mobile.matches || nav.contains(document.activeElement)) {
+            show();
+            return;
+        }
+        if (Math.abs(delta) < MIN_DELTA) {
+            return;
+        }
+        var doc = document.documentElement;
+        var atBottom = (y + window.innerHeight) >= (doc.scrollHeight - 4);
+        if (y <= STOW_BELOW || delta < 0 || atBottom) {
+            show();
+        } else {
+            nav.classList.add('site-nav--stowed');
+        }
+    }
+
+    window.addEventListener('scroll', function() {
+        if (!queued) {
+            queued = true;
+            window.requestAnimationFrame(update);
+        }
+    }, { passive: true });
+    // Focusing the search must always bring the bar back, even without a scroll.
+    nav.addEventListener('focusin', show);
+    if (mobile.addEventListener) {
+        mobile.addEventListener('change', show);
+    } else if (mobile.addListener) {
+        mobile.addListener(show);
+    }
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initStowingNav);
+} else {
+    initStowingNav();
+}
+
 function refreshAuthState() {
     return apiJSON('/v1/auth/me', { method: 'GET' })
         .then(function(resp) {

--- a/src/main/resources/static/js/rewayaat.js
+++ b/src/main/resources/static/js/rewayaat.js
@@ -44,6 +44,7 @@ var READING_PAGE_SIZE = 50;
 var INITIAL_VISIBLE_NARRATIONS = 16;
 var REVEAL_BATCH_SIZE = 12;
 var INITIAL_VISIBLE_TAG_FILTERS = 15;
+var NOTES_COLLAPSE_THRESHOLD = 600;
 var similarLoadingMinDurationMs = 550;
 var scopeFieldKeys = ['book', 'volume', 'part', 'section', 'chapter'];
 var SIDECAR_WIDTH_STORAGE_KEY = 'rewayaat_sidecar_width';
@@ -4447,6 +4448,7 @@ function setupVue(query, page, sortFields) {
             arabicSuggestionToastShown: false,
             arabicSuggestionThresholdPassed: false,
             snippetExpandedKeys: {},
+            notesExpandedKeys: {},
             collections: userCollectionsCache,
             collectionSearchQuery: '',
             sidecarWidth: 304,
@@ -6133,6 +6135,23 @@ function setupVue(query, page, sortFields) {
             toggleSnippetExpand: function(narration, sidx) {
                 var key = this.snippetExpandKey(narration, sidx);
                 Vue.set(this.snippetExpandedKeys, key, !this.snippetExpandedKeys[key]);
+            },
+            notesExpandKey: function(narration) {
+                return (narration._id || narration.id || '') + '-notes';
+            },
+            // Long notes are previewed rather than shown in full: the reading
+            // card is height-capped, so an unbounded note squeezes the
+            // narration text out of the layout entirely.
+            isNotesCollapsible: function(narration) {
+                var notes = (narration && narration.notes) || '';
+                return notes.replace(/<[^>]*>/g, '').trim().length > NOTES_COLLAPSE_THRESHOLD;
+            },
+            isNotesExpanded: function(narration) {
+                return !!this.notesExpandedKeys[this.notesExpandKey(narration)];
+            },
+            toggleNotesExpand: function(narration) {
+                var key = this.notesExpandKey(narration);
+                Vue.set(this.notesExpandedKeys, key, !this.notesExpandedKeys[key]);
             },
             quranContextSegments: function(narration) {
                 var insight = this.activeQuranicInsight(narration);

--- a/src/main/resources/static/js/rewayaat.js
+++ b/src/main/resources/static/js/rewayaat.js
@@ -45,6 +45,7 @@ var INITIAL_VISIBLE_NARRATIONS = 16;
 var REVEAL_BATCH_SIZE = 12;
 var INITIAL_VISIBLE_TAG_FILTERS = 15;
 var NOTES_COLLAPSE_THRESHOLD = 600;
+var NARRATION_COLLAPSE_THRESHOLD = 700;
 var similarLoadingMinDurationMs = 550;
 var scopeFieldKeys = ['book', 'volume', 'part', 'section', 'chapter'];
 var SIDECAR_WIDTH_STORAGE_KEY = 'rewayaat_sidecar_width';
@@ -4513,6 +4514,7 @@ function setupVue(query, page, sortFields) {
             arabicSuggestionThresholdPassed: false,
             snippetExpandedKeys: {},
             notesExpandedKeys: {},
+            narrationExpandedKeys: {},
             collections: userCollectionsCache,
             collectionSearchQuery: '',
             sidecarWidth: 304,
@@ -6239,6 +6241,32 @@ function setupVue(query, page, sortFields) {
             toggleSnippetExpand: function(narration, sidx) {
                 var key = this.snippetExpandKey(narration, sidx);
                 Vue.set(this.snippetExpandedKeys, key, !this.snippetExpandedKeys[key]);
+            },
+            // A long narration must not force the reader to scroll past the
+            // whole text to reach the next result, so cards stay scannable and
+            // long ones open on request. A clamp rather than an inner scroll
+            // region, so the page keeps a single scrollbar.
+            narrationExpandKey: function(narration) {
+                return (narration._id || narration.id || '') + '-narration';
+            },
+            isNarrationCollapsible: function(narration) {
+                if (!narration) {
+                    return false;
+                }
+                var en = narration.englishContent || narration.english || '';
+                var ar = narration.arabicContent || narration.arabic || '';
+                var longest = Math.max(
+                    en.replace(/<[^>]*>/g, '').trim().length,
+                    ar.replace(/<[^>]*>/g, '').trim().length
+                );
+                return longest > NARRATION_COLLAPSE_THRESHOLD;
+            },
+            isNarrationExpanded: function(narration) {
+                return !!this.narrationExpandedKeys[this.narrationExpandKey(narration)];
+            },
+            toggleNarrationExpand: function(narration) {
+                var key = this.narrationExpandKey(narration);
+                Vue.set(this.narrationExpandedKeys, key, !this.narrationExpandedKeys[key]);
             },
             notesExpandKey: function(narration) {
                 return (narration._id || narration.id || '') + '-notes';

--- a/src/main/resources/static/js/rewayaat.js
+++ b/src/main/resources/static/js/rewayaat.js
@@ -46,6 +46,7 @@ var REVEAL_BATCH_SIZE = 12;
 var INITIAL_VISIBLE_TAG_FILTERS = 15;
 var NOTES_COLLAPSE_THRESHOLD = 600;
 var NARRATION_COLLAPSE_THRESHOLD = 700;
+var MOBILE_VISIBLE_TAGS = 2;
 var similarLoadingMinDurationMs = 550;
 var scopeFieldKeys = ['book', 'volume', 'part', 'section', 'chapter'];
 var SIDECAR_WIDTH_STORAGE_KEY = 'rewayaat_sidecar_width';
@@ -4816,14 +4817,15 @@ function setupVue(query, page, sortFields) {
             },
             visibleNarrationTopicTags: function(narration) {
                 var tags = Array.isArray(narration && narration.topic_tags) ? narration.topic_tags : [];
-                if (!this.isMobileViewport() || narration.mobileTagsExpanded || tags.length <= 5) {
+                if (!this.isMobileViewport() || narration.mobileTagsExpanded
+                        || tags.length <= MOBILE_VISIBLE_TAGS) {
                     return tags;
                 }
-                return tags.slice(0, 5);
+                return tags.slice(0, MOBILE_VISIBLE_TAGS);
             },
             shouldShowNarrationTagToggle: function(narration) {
                 var tags = Array.isArray(narration && narration.topic_tags) ? narration.topic_tags : [];
-                return this.isMobileViewport() && tags.length > 5;
+                return this.isMobileViewport() && tags.length > MOBILE_VISIBLE_TAGS;
             },
             toggleNarrationTags: function(narration) {
                 if (!narration) {

--- a/src/main/resources/static/js/rewayaat.js
+++ b/src/main/resources/static/js/rewayaat.js
@@ -5606,6 +5606,42 @@ function setupVue(query, page, sortFields) {
                     element.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 }
             },
+            // The card is no longer height-capped, so an opened related/tafsir
+            // panel can sit below the fold and the click looks like a no-op.
+            // The panel renders only once its content has loaded, and the
+            // loading state has a minimum duration, so poll briefly rather
+            // than guess at the timing.
+            revealNarrationPanel: function(narration, tab) {
+                var self = this;
+                var domId = this.narrationDomId(narration);
+                if (!domId || typeof window === 'undefined' || !window.requestAnimationFrame) {
+                    return;
+                }
+                var deadline = Date.now() + 2500;
+                var reduced = window.matchMedia
+                    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+                function attempt() {
+                    // Bail if the reader moved on while the panel was loading.
+                    if (self.activeNarrationSidecarTab(narration) !== tab) {
+                        return;
+                    }
+                    var card = document.getElementById(domId);
+                    var panel = card ? card.querySelector('.hadith-inline-context') : null;
+                    if (panel && panel.scrollIntoView) {
+                        // 'nearest' is deliberate: it does nothing when the panel is
+                        // already visible, so the page is never yanked around.
+                        panel.scrollIntoView({
+                            behavior: reduced ? 'auto' : 'smooth',
+                            block: 'nearest'
+                        });
+                        return;
+                    }
+                    if (Date.now() < deadline) {
+                        window.requestAnimationFrame(attempt);
+                    }
+                }
+                this.$nextTick(attempt);
+            },
             activeNarrationSidecarTab: function(narration) {
                 if (!narration) {
                     return 'metadata';
@@ -5633,6 +5669,9 @@ function setupVue(query, page, sortFields) {
                 }
                 if (nextTab === 'quran' && !narration.quranicInsightsItemsLoaded && !narration.quranicInsightsItemsLoading) {
                     this.fetchQuranicInsights(narration, true);
+                }
+                if (nextTab === 'similar' || nextTab === 'quran') {
+                    this.revealNarrationPanel(narration, nextTab);
                 }
             },
             isNarrationSidecarTabActive: function(narration, tab) {
@@ -5803,6 +5842,7 @@ function setupVue(query, page, sortFields) {
                 }
                 narration.similarActiveIndex = index;
                 narration.sidecarActiveTab = 'similar';
+                this.revealNarrationPanel(narration, 'similar');
             },
             quranicInsightsCountText: function(narration) {
                 if (!narration || typeof narration.quranicInsightsCount !== 'number' || narration.quranicInsightsCount <= 0) {

--- a/src/main/resources/templates/hadith.html
+++ b/src/main/resources/templates/hadith.html
@@ -59,7 +59,6 @@
         .hp-meta-row { display: flex; flex-wrap: wrap; gap: 1rem 2rem; margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--bs-border-color); }
         .hp-meta-item { font-size: 0.85rem; }
         .hp-meta-item__label { color: var(--bs-secondary-color); font-weight: 500; }
-        .hp-notes { margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--bs-border-color); font-size: 0.9rem; color: var(--bs-secondary-color); }
         .hp-back { display: inline-flex; align-items: center; gap: 0.4rem; margin-top: 2rem; font-size: 0.9rem; color: var(--bs-secondary-color); text-decoration: none; }
         .hp-back:hover { color: var(--bs-body-color); }
         .hp-share__btn { background: none; border: 1px solid var(--bs-border-color); border-radius: 999px; padding: 0.35rem 1rem; font-size: 0.85rem; color: var(--bs-secondary-color); cursor: pointer; transition: all 0.2s; font-family: inherit; }
@@ -208,10 +207,25 @@
             </div>
         </div>
 
-        <!-- Notes -->
-        <div class="hp-notes"
-             th:if="${hadith.notes != null and !hadith.notes.isBlank()}">
-            <div th:utext="${hadith.notes}">Notes content</div>
+        <!-- Notes: same apparatus panel as the results page, so the note reads
+             the same however the reader arrived at the hadith. -->
+        <div class="hadith-notes mt-3"
+             th:if="${hadith.notes != null and !hadith.notes.isBlank()}"
+             th:with="collapsible=${hadith.notes.length() > 600}">
+            <div class="hadith-notes__head">
+                <span class="hadith-notes__label">Notes</span>
+            </div>
+            <div class="hadith-notes__body"
+                 id="hadithNotesBody"
+                 th:classappend="${collapsible} ? 'hadith-notes__body--clamped' : ''"
+                 th:utext="${hadith.notes}">Notes content</div>
+            <button type="button"
+                    class="hadith-notes__toggle"
+                    id="hadithNotesToggle"
+                    th:if="${collapsible}"
+                    aria-expanded="false"
+                    aria-controls="hadithNotesBody"
+                    onclick="toggleHadithNotes()">Show more</button>
         </div>
 
         <!-- Back to search -->
@@ -290,6 +304,14 @@
                 fallbackCopy();
             }
         }
+    }
+    function toggleHadithNotes() {
+        var body = document.getElementById('hadithNotesBody');
+        var btn = document.getElementById('hadithNotesToggle');
+        if (!body || !btn) return;
+        var clamped = body.classList.toggle('hadith-notes__body--clamped');
+        btn.setAttribute('aria-expanded', clamped ? 'false' : 'true');
+        btn.textContent = clamped ? 'Show more' : 'Show less';
     }
     function showShareToast() {
         var toast = document.getElementById('shareToast');

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -580,7 +580,8 @@
                                         <span class="hadith-card__ornament-mark">۞</span>
                                         <span class="hadith-card__ornament-line"></span>
                                     </div>
-                                    <div class="hadith-reading-scroll">
+                                    <div class="hadith-reading-scroll"
+                                         v-bind:class="{'hadith-reading-scroll--clamped': isNarrationCollapsible(narration) && !isNarrationExpanded(narration)}">
                                         <div class="row g-4 hadith-reading-row">
                                             <div class="col-12 col-lg-6">
                                                 <div class="hadith-text-block hadith-text-block--primary">
@@ -598,6 +599,13 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <button type="button"
+                                            class="hadith-reading-toggle"
+                                            v-if="isNarrationCollapsible(narration)"
+                                            v-bind:aria-expanded="isNarrationExpanded(narration) ? 'true' : 'false'"
+                                            v-on:click="toggleNarrationExpand(narration)">
+                                        {{ isNarrationExpanded(narration) ? 'Show less' : 'Show full hadith' }}
+                                    </button>
                                     <!-- Notes gloss the narration itself, so they sit with the text,
                                          above the similar/tafsir panels which are separate corpora. -->
                                     <div class="hadith-notes mt-3" v-if="narration.notes">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -604,7 +604,10 @@
                                             v-if="isNarrationCollapsible(narration)"
                                             v-bind:aria-expanded="isNarrationExpanded(narration) ? 'true' : 'false'"
                                             v-on:click="toggleNarrationExpand(narration)">
-                                        {{ isNarrationExpanded(narration) ? 'Show less' : 'Show full hadith' }}
+                                        <i class="fa"
+                                           v-bind:class="isNarrationExpanded(narration) ? 'fa-chevron-up' : 'fa-book-open'"
+                                           aria-hidden="true"></i>
+                                        <span>{{ isNarrationExpanded(narration) ? 'Show less' : 'Show full hadith' }}</span>
                                     </button>
                                     <!-- Notes gloss the narration itself, so they sit with the text,
                                          above the similar/tafsir panels which are separate corpora. -->

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -605,11 +605,14 @@
                                             <span class="hadith-notes__label">Notes</span>
                                         </div>
                                         <div class="hadith-notes__body"
+                                             v-bind:id="narrationDomId(narration) + '-notes'"
                                              v-bind:class="{'hadith-notes__body--clamped': isNotesCollapsible(narration) && !isNotesExpanded(narration)}"
                                              v-html="narration.notes"></div>
                                         <button type="button"
                                                 class="hadith-notes__toggle"
                                                 v-if="isNotesCollapsible(narration)"
+                                                v-bind:aria-expanded="isNotesExpanded(narration) ? 'true' : 'false'"
+                                                v-bind:aria-controls="narrationDomId(narration) + '-notes'"
                                                 v-on:click="toggleNotesExpand(narration)">
                                             {{ isNotesExpanded(narration) ? 'Show less' : 'Show more' }}
                                         </button>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -598,6 +598,22 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <!-- Notes gloss the narration itself, so they sit with the text,
+                                         above the similar/tafsir panels which are separate corpora. -->
+                                    <div class="hadith-notes mt-3" v-if="narration.notes">
+                                        <div class="hadith-notes__head">
+                                            <span class="hadith-notes__label">Notes</span>
+                                        </div>
+                                        <div class="hadith-notes__body"
+                                             v-bind:class="{'hadith-notes__body--clamped': isNotesCollapsible(narration) && !isNotesExpanded(narration)}"
+                                             v-html="narration.notes"></div>
+                                        <button type="button"
+                                                class="hadith-notes__toggle"
+                                                v-if="isNotesCollapsible(narration)"
+                                                v-on:click="toggleNotesExpand(narration)">
+                                            {{ isNotesExpanded(narration) ? 'Show less' : 'Show more' }}
+                                        </button>
+                                    </div>
                                     <div class="hadith-inline-context hadith-inline-context--similar"
                                          v-if="activeNarrationSidecarTab(narration) === 'similar' && activeSimilar(narration)">
                                         <div class="hadith-inline-context__meta-band hadith-inline-context__meta-band--compact">
@@ -707,7 +723,6 @@
                                             Select a tafsir source from the verse tree to read its snippet here.
                                         </div>
                                     </div>
-                                    <div class="hadith-notes mt-3" v-if="narration.notes" v-html="narration.notes"></div>
                                     <div class="hadith-card__footer">
                                         <div class="topic-tag-pills hadith-card__tags"
                                              v-if="narration.topic_tags && narration.topic_tags.length > 0">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -605,7 +605,7 @@
                                             v-bind:aria-expanded="isNarrationExpanded(narration) ? 'true' : 'false'"
                                             v-on:click="toggleNarrationExpand(narration)">
                                         <i class="fa"
-                                           v-bind:class="isNarrationExpanded(narration) ? 'fa-chevron-up' : 'fa-book-open'"
+                                           v-bind:class="isNarrationExpanded(narration) ? 'fa-chevron-up' : 'fa-chevron-down'"
                                            aria-hidden="true"></i>
                                         <span>{{ isNarrationExpanded(narration) ? 'Show less' : 'Show full hadith' }}</span>
                                     </button>


### PR DESCRIPTION
Reported by a reader: on [Al-Khiṣāl #989](https://rewayaat.info/?q=book%3A%22Al-Khi%E1%B9%A3%C4%81l%22%20number%3A%22989%22&page=1&match_mode=flexible) the hadith was completely invisible — "the Hadith is completely hidden behind the note".

## The bug

The reading card was capped at `min(90dvh, 60rem)`, giving `.hadith-content` a definite height whose children then compete for it. `.hadith-reading-scroll` was the only one that could give ground: `overflow-y: auto` makes its automatic minimum size resolve to `0`, while the notes, footer and ornament have `overflow: visible` and cannot shrink below their content. A 2,944-character note therefore absorbed none of the shrinkage and the narration was squeezed to `height: 0` — present in the DOM, completely invisible.

Only 11 of 32,519 hadith have notes, and 3 are long enough to trigger it.

## The fix

The card grows to fit instead of making the text pay for everything else, and long content is previewed rather than scrolled:

- Narrations over 700 chars show a ~4 line preview with a **Show full hadith** control; notes over 600 chars do the same. Keeps result cards scannable (551–656px, median 562) without an inner scrollbar.
- No nested scroll region on the card — one scrollbar, on the page. Nested scrolling made the wheel latch unpredictably.
- Inner scroll regions no longer set `overscroll-behavior: contain`, so reaching the end of the tafsir list continues the page scroll instead of dead-ending.
- Collapsing pins the button's on-screen position so the hadith doesn't scroll out from under you.
- Notes render as a distinct teal apparatus panel, above the related/tafsir panels (they gloss the narration, not those corpora), and the detail page now uses the same panel instead of plain `.hp-notes`.

## Mobile

- Single-row header: search sits between logo and menu. **156px → 61px**. Applied below 992px, since a landscape phone is ~844px wide and was still getting the tall header — 120px out of a 390px-tall viewport.
- Search terms stay on one line and scroll sideways instead of wrapping the bar to three rows.
- Partially persistent header (NN/g): stows on scroll down, returns on scroll up, at the top, and at the bottom. `translateY` so there's no reflow; never stows while focus is inside the nav.
- Sidecar count badges sit on their icon's corner rather than the tab's.
- Fixed the narration spilling over the tag row.

## Accessibility

- Toggle hit areas extended to 44×44 without inflating the visual pills (115×47 measured by hit-testing).
- `aria-expanded` / `aria-controls` on both toggles.
- `prefers-reduced-motion` honoured — there was no handling of it anywhere in the codebase before.
- Contrast verified: notes body 5.86:1, labels 5.13:1, show-hadith button 15.7:1, search field text 12.7:1.

## Verification

- 413 tests pass, clean build
- 30/30 matrix: 6 viewports (390×844 → 1920×1080) × 5 note lengths + a no-notes control
- Scroll chaining, toggle round-trips and header stow/reveal driven by real wheel/click events via CDP
- Reading pane on #989: **0px → 648px**, and stable when notes expand or a panel opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)