### PR TITLE
fix: populate the hadith sitemap instead of serving an empty urlset

### DIFF
--- a/src/main/java/com/rewayaat/controllers/SitemapController.java
+++ b/src/main/java/com/rewayaat/controllers/SitemapController.java
@@ -1,11 +1,14 @@
 package com.rewayaat.controllers;
 
 import com.rewayaat.config.ESClientProvider;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -28,11 +31,19 @@ public class SitemapController {
     private static final String BASE_URL = "https://hadith.academyofislam.com";
     private static final int PAGE_SIZE = 10000;
     private static final int ES_MAX_RESULT_WINDOW = 10000;
+    private static final String PIT_KEEP_ALIVE = "5m";
 
     @RequestMapping(value = "/sitemap.xml", method = RequestMethod.GET, produces = MediaType.APPLICATION_XML_VALUE)
     public ResponseEntity<String> sitemapIndex() {
         LOGGER.debug("Generating sitemap index");
-        long total = totalHadithCount();
+        long total;
+        try {
+            total = totalHadithCount();
+        } catch (Exception e) {
+            // Better a 5xx than a sitemap index that silently under-reports the corpus.
+            LOGGER.error("Error counting hadith for sitemap index", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
         int totalPages = Math.max(1, (int) Math.ceil((double) total / PAGE_SIZE));
 
         StringBuilder xml = new StringBuilder();
@@ -81,17 +92,22 @@ public class SitemapController {
             page = 1;
         }
 
+        List<String> ids;
+        try {
+            ids = fetchHadithIds(page);
+        } catch (Exception e) {
+            // A well-formed but empty urlset looks healthy to crawlers and to monitoring,
+            // so surface the failure as a 5xx instead of hiding it behind a 200.
+            LOGGER.error("Error fetching hadith IDs for sitemap page {}", page, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
         StringBuilder xml = new StringBuilder();
         xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
 
-        try {
-            List<String> ids = fetchHadithIds(page);
-            for (String id : ids) {
-                appendUrl(xml, "/hadith/" + escapeXml(id), "0.8", "monthly");
-            }
-        } catch (Exception e) {
-            LOGGER.error("Error fetching hadith IDs for sitemap page {}", page, e);
+        for (String id : ids) {
+            appendUrl(xml, "/hadith/" + escapeXml(id), "0.8", "monthly");
         }
 
         xml.append("</urlset>");
@@ -102,55 +118,84 @@ public class SitemapController {
 
     /**
      * Fetches hadith IDs for a given sitemap page using search_after pagination.
+     *
+     * <p>Pagination runs against a Point-In-Time so the walk sees a consistent snapshot,
+     * sorted by {@code _shard_doc}. Sorting on {@code _id} is not an option: Elasticsearch 9
+     * disallows fielddata on that field, which fails the whole search.
      */
     private List<String> fetchHadithIds(int page) throws Exception {
         try (ESClientProvider provider = new ESClientProvider()) {
+            ElasticsearchClient client = provider.client();
             List<String> allIds = new ArrayList<>();
-            String searchAfter = null;
 
-            // We need to walk through pages of 10K to reach the desired offset,
-            // then return the IDs for that page.
-            for (int current = 1; current <= page; current++) {
-                final String afterValue = searchAfter;
-                SearchResponse<Void> response = provider.client().search(s -> {
-                    s.index(ESClientProvider.INDEX)
-                            .size(PAGE_SIZE)
-                            .source(src -> src.fetch(false))
-                            .sort(so -> so.field(f -> f.field("_id").order(SortOrder.Asc)));
-                    if (afterValue != null) {
-                        s.searchAfter(afterValue);
+            String pitId = client.openPointInTime(p -> p
+                    .index(ESClientProvider.INDEX)
+                    .keepAlive(t -> t.time(PIT_KEEP_ALIVE))).id();
+
+            try {
+                List<FieldValue> searchAfter = null;
+
+                // We need to walk through pages of 10K to reach the desired offset,
+                // then return the IDs for that page.
+                for (int current = 1; current <= page; current++) {
+                    final String currentPitId = pitId;
+                    final List<FieldValue> afterValue = searchAfter;
+                    SearchResponse<Void> response = client.search(s -> {
+                        // The index is carried by the PIT, so it must not be set here.
+                        s.size(PAGE_SIZE)
+                                .trackTotalHits(t -> t.enabled(false))
+                                .source(src -> src.fetch(false))
+                                .pit(p -> p.id(currentPitId).keepAlive(t -> t.time(PIT_KEEP_ALIVE)))
+                                .sort(so -> so.field(f -> f.field("_shard_doc").order(SortOrder.Asc)));
+                        if (afterValue != null) {
+                            s.searchAfter(afterValue);
+                        }
+                        return s;
+                    }, Void.class);
+
+                    // Elasticsearch may hand back a refreshed PIT id on each search.
+                    if (response.pitId() != null) {
+                        pitId = response.pitId();
                     }
-                    return s;
-                }, Void.class);
 
-                List<Hit<Void>> hits = response.hits().hits();
-                if (hits.isEmpty()) {
-                    break;
-                }
-
-                if (current == page) {
-                    for (Hit<Void> hit : hits) {
-                        allIds.add(hit.id());
+                    List<Hit<Void>> hits = response.hits().hits();
+                    if (hits.isEmpty()) {
+                        break;
                     }
-                } else {
-                    searchAfter = hits.get(hits.size() - 1).id();
+
+                    if (current == page) {
+                        for (Hit<Void> hit : hits) {
+                            allIds.add(hit.id());
+                        }
+                    } else {
+                        searchAfter = hits.get(hits.size() - 1).sort();
+                    }
                 }
+            } finally {
+                closePointInTime(client, pitId);
             }
 
             return allIds;
         }
     }
 
-    private long totalHadithCount() {
+    /** Releases a Point-In-Time without masking any exception already in flight. */
+    private void closePointInTime(ElasticsearchClient client, String pitId) {
+        try {
+            client.closePointInTime(c -> c.id(pitId));
+        } catch (Exception e) {
+            LOGGER.warn("Error closing Point-In-Time for sitemap generation", e);
+        }
+    }
+
+    private long totalHadithCount() throws IOException {
         try (ESClientProvider provider = new ESClientProvider()) {
             SearchResponse<Void> response = provider.client().search(s -> {
-                s.index(ESClientProvider.INDEX).size(0);
+                // Without this Elasticsearch caps the reported total at 10,000.
+                s.index(ESClientProvider.INDEX).size(0).trackTotalHits(t -> t.enabled(true));
                 return s;
             }, Void.class);
             return response.hits().total().value();
-        } catch (IOException e) {
-            LOGGER.error("Error counting hadith for sitemap", e);
-            return 0;
         }
     }
 

--- a/src/test/java/com/rewayaat/integration/SitemapIntegrationTest.java
+++ b/src/test/java/com/rewayaat/integration/SitemapIntegrationTest.java
@@ -1,0 +1,204 @@
+package com.rewayaat.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rewayaat.config.ESClientProvider;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the two ways the hadith sitemap has silently gone missing: a search failure
+ * that emitted a well-formed but empty urlset, and a page count derived from a total
+ * Elasticsearch caps at 10,000.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SitemapIntegrationTest extends ElasticsearchTestSupport {
+
+    private static final String BASE_URL = "https://hadith.academyofislam.com";
+    private static final int PAGE_SIZE = 10000;
+    private static final int BULK_BATCH_SIZE = 2000;
+    private static final long VISIBILITY_TIMEOUT_MS = 30000L;
+    private static final String MISSING_INDEX = "rewayaat_index_that_does_not_exist";
+
+    private static final Pattern LOC = Pattern.compile("<loc>(.*?)</loc>");
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void hadithSitemap_listsIndexedHadith() throws Exception {
+        indexDoc("Al-Kafi-Volume-2-Kulayni:391", "{\"english\":\"hello world\"}");
+        indexDoc("Uyun-akhbar-al-Rida-Volume-1-Saduq:145", "{\"english\":\"hello there\"}");
+        indexDoc("Nahj-al-Balagha-Sharif-al-Radi:1", "{\"english\":\"help needed\"}");
+
+        ResponseEntity<String> response = restTemplate.getForEntity("/sitemap-hadith-1.xml", String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        List<String> locs = locations(response.getBody());
+        assertEquals(3, locs.size(), () -> "Expected one <loc> per indexed hadith, got: " + locs);
+        assertTrue(locs.contains(BASE_URL + "/hadith/Al-Kafi-Volume-2-Kulayni:391"), () -> "Missing hadith URL in " + locs);
+        assertTrue(locs.contains(BASE_URL + "/hadith/Uyun-akhbar-al-Rida-Volume-1-Saduq:145"), () -> "Missing hadith URL in " + locs);
+        assertTrue(locs.contains(BASE_URL + "/hadith/Nahj-al-Balagha-Sharif-al-Radi:1"), () -> "Missing hadith URL in " + locs);
+    }
+
+    @Test
+    void sitemapIndex_countsHadithPagesBeyondTheTenThousandHitCap() throws Exception {
+        int total = PAGE_SIZE + 1;
+        bulkIndexStubs(total);
+
+        ResponseEntity<String> response = restTemplate.getForEntity("/sitemap.xml", String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        List<String> locs = locations(response.getBody());
+        assertTrue(locs.contains(BASE_URL + "/sitemap-static.xml"), () -> "Static sitemap missing from index: " + locs);
+
+        List<String> hadithSitemaps = new ArrayList<>();
+        for (String loc : locs) {
+            if (loc.contains("/sitemap-hadith-")) {
+                hadithSitemaps.add(loc);
+            }
+        }
+        // 10,001 documents span two pages. Reading hits().total() without track_total_hits
+        // caps the total at 10,000 and advertises a single page, hiding the overflow.
+        assertEquals(2, hadithSitemaps.size(), () -> "Expected two hadith sitemap pages, got: " + hadithSitemaps);
+        assertTrue(hadithSitemaps.contains(BASE_URL + "/sitemap-hadith-1.xml"), () -> "Missing page 1 in " + hadithSitemaps);
+        assertTrue(hadithSitemaps.contains(BASE_URL + "/sitemap-hadith-2.xml"), () -> "Missing page 2 in " + hadithSitemaps);
+    }
+
+    @Test
+    void hadithSitemap_pagesThroughEveryDocumentWithoutDuplicates() throws Exception {
+        int total = PAGE_SIZE + 1;
+        bulkIndexStubs(total);
+
+        List<String> firstPage = locations(okBody("/sitemap-hadith-1.xml"));
+        List<String> secondPage = locations(okBody("/sitemap-hadith-2.xml"));
+
+        assertEquals(PAGE_SIZE, firstPage.size(), "First sitemap page should be full");
+        assertEquals(total - PAGE_SIZE, secondPage.size(), "Second sitemap page should hold the remainder");
+
+        Set<String> unique = new HashSet<>(firstPage);
+        unique.addAll(secondPage);
+        assertEquals(total, unique.size(), "Every indexed hadith should appear exactly once across the pages");
+        for (String loc : unique) {
+            assertTrue(loc.startsWith(BASE_URL + "/hadith/"), () -> "Unexpected sitemap URL: " + loc);
+        }
+    }
+
+    @Test
+    void staticSitemap_doesNotDependOnElasticsearch() {
+        withMissingIndex(() -> {
+            ResponseEntity<String> response = restTemplate.getForEntity("/sitemap-static.xml", String.class);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            List<String> locs = locations(response.getBody());
+            assertTrue(locs.contains(BASE_URL + "/"), () -> "Missing home page URL in " + locs);
+            assertTrue(locs.contains(BASE_URL + "/search_tips.html"), () -> "Missing search tips URL in " + locs);
+        });
+    }
+
+    @Test
+    void hadithSitemap_failsLoudlyWhenElasticsearchIsUnavailable() {
+        withMissingIndex(() -> {
+            // A well-formed empty urlset served with 200 looks healthy to crawlers and to
+            // monitoring, which is exactly how the empty sitemap went unnoticed.
+            ResponseEntity<String> response = restTemplate.getForEntity("/sitemap-hadith-1.xml", String.class);
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        });
+    }
+
+    @Test
+    void sitemapIndex_failsLoudlyWhenElasticsearchIsUnavailable() {
+        withMissingIndex(() -> {
+            ResponseEntity<String> response = restTemplate.getForEntity("/sitemap.xml", String.class);
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        });
+    }
+
+    private String okBody(String path) {
+        ResponseEntity<String> response = restTemplate.getForEntity(path, String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode(), () -> path + " should be served");
+        return response.getBody();
+    }
+
+    private List<String> locations(String xml) {
+        assertNotNull(xml, "Sitemap body should not be null");
+        List<String> locs = new ArrayList<>();
+        Matcher matcher = LOC.matcher(xml);
+        while (matcher.find()) {
+            locs.add(matcher.group(1));
+        }
+        return locs;
+    }
+
+    /** Points the controller at an index that does not exist, so every search fails. */
+    private void withMissingIndex(Runnable body) {
+        System.setProperty("REWAYAAT_INDEX", MISSING_INDEX);
+        ESClientProvider.resetIndex();
+        try {
+            body.run();
+        } finally {
+            System.setProperty("REWAYAAT_INDEX", INDEX);
+            ESClientProvider.resetIndex();
+        }
+    }
+
+    private void indexDoc(String id, String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> doc = mapper.readValue(json, new TypeReference<Map<String, Object>>() {
+        });
+        client.index(i -> i.index(INDEX).id(id).document(doc).refresh(Refresh.True));
+    }
+
+    private void bulkIndexStubs(int count) throws Exception {
+        for (int start = 0; start < count; start += BULK_BATCH_SIZE) {
+            int end = Math.min(start + BULK_BATCH_SIZE, count);
+            List<BulkOperation> operations = new ArrayList<>();
+            for (int i = start; i < end; i++) {
+                String id = "stub-hadith-" + i;
+                Map<String, Object> doc = Map.of("english", "stub narration " + i);
+                operations.add(BulkOperation.of(op -> op.index(idx -> idx.index(INDEX).id(id).document(doc))));
+            }
+            BulkResponse response = client.bulk(b -> b.index(INDEX).operations(operations));
+            assertFalse(response.errors(), "Bulk indexing of sitemap stubs reported errors");
+        }
+        client.indices().refresh(r -> r.index(INDEX));
+        awaitVisible(count);
+    }
+
+    /** Waits for the freshly bulk-indexed stubs to become searchable before the sitemap is requested. */
+    private void awaitVisible(int expected) throws Exception {
+        long deadline = System.currentTimeMillis() + VISIBILITY_TIMEOUT_MS;
+        long indexed = 0;
+        while (System.currentTimeMillis() < deadline) {
+            indexed = client.count(c -> c.index(INDEX)).count();
+            if (indexed == expected) {
+                return;
+            }
+            Thread.sleep(100);
+            client.indices().refresh(r -> r.index(INDEX));
+        }
+        final long lastSeen = indexed;
+        assertEquals(expected, lastSeen, "Seeded documents never became searchable");
+    }
+}


### PR DESCRIPTION
Closes #65.

`sitemap-hadith-1.xml` served a well-formed but empty `<urlset>`, so none of the 32,519 hadith detail pages were discoverable by crawlers. Two independent causes, both fixed here.

## 1. Sort on `_id` threw — this is what emptied the sitemap

`fetchHadithIds()` paginated with `.sort(f -> f.field("_id"))`. Elasticsearch 9 disallows fielddata on `_id`, so every search failed; the exception was caught, logged, and the method fell through to emit an empty sitemap with HTTP 200.

Replaced with a Point-In-Time walk sorted by `_shard_doc` — no fielddata required, and it gives a consistent snapshot across the paged walk. `_source` stays off and ids still come from `hit.id()`; the cursor is now `hit.sort()` rather than the id. The PIT is released in a `finally`, and the close never masks an exception already in flight.

## 2. `totalHadithCount()` was capped at 10,000

It read `hits().total().value()` with no `track_total_hits`, which Elasticsearch caps at 10,000, so `totalPages` computed to 1 instead of 4. Even with (1) fixed, ~22,500 hadith would still have been missing. Now sets `track_total_hits(true)`.

## 3. No more silent failure

Both sitemap endpoints return 500 on an Elasticsearch failure instead of a healthy-looking empty sitemap, so this can't regress silently again.

## Verified

Against the real local Elasticsearch 9.0.2 (`rewayaat_updated`, 32,519 docs), with the app actually running from this branch on a spare port under the `dev` profile:

**Bug reproduced first**, on the running pre-fix instance: `sitemap-hadith-1.xml` returned the empty `<urlset>`, and `sitemap.xml` listed only one hadith sitemap.

**Root causes confirmed by direct curl** before touching Java: the `_id` sort returns `"Fielddata access on the _id field is disallowed"`; `{"size":0}` reports `{"value":10000,"relation":"gte"}` while `track_total_hits:true` reports `{"value":32519,"relation":"eq"}`.

**After the fix**, served by the app:

| Endpoint | Result |
|---|---|
| `sitemap.xml` | lists 4 hadith sitemaps |
| `sitemap-hadith-1.xml` | 200, 10,000 `<loc>` |
| `sitemap-hadith-2.xml` | 200, 10,000 `<loc>` |
| `sitemap-hadith-3.xml` | 200, 10,000 `<loc>` |
| `sitemap-hadith-4.xml` | 200, 2,519 `<loc>` |

Total across the four pages: **32,519 `<loc>` entries, all unique**, exactly matching `_count` on the index. Sampled URLs (`/hadith/Al-Kafi-Volume-2-Kulayni:391`, `/hadith/Uyun-akhbar-al-Rida-Volume-1-Saduq:145`) return 200 and render real hadith text.

**Error path**: a second instance pointed at a nonexistent index returned 500 for both `sitemap.xml` and `sitemap-hadith-1.xml` (and 200 for `sitemap-static.xml`, which doesn't touch Elasticsearch) — confirming the failure surfaces rather than masquerading as an empty sitemap.

**No PIT leak**: `_nodes/stats` reported `open_contexts: 0` after roughly ten full sitemap walks.

**Tests**: `mvn test` — 413 tests, 0 failures, 0 errors. Note there are no pre-existing tests covering `SitemapController`; the verification above is end-to-end against the running app rather than unit-test coverage.

## Out of scope

Left alone deliberately, per the issue: `fetchHadithIds(page)` still re-walks preceding pages to reach `page`, and `lastmod` is still `LocalDate.now()` for every URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017H2pVwWfyUkFmTSk8VrqUZ
