### PR TITLE
perf: stop exposing the 1024-dim semantic_vector in API responses

### DIFF
--- a/src/main/java/com/rewayaat/controllers/HadithPageController.java
+++ b/src/main/java/com/rewayaat/controllers/HadithPageController.java
@@ -2,6 +2,7 @@ package com.rewayaat.controllers;
 
 import com.rewayaat.config.ESClientProvider;
 import com.rewayaat.core.HadithDisplaySegmenter;
+import com.rewayaat.core.HadithSourceFilter;
 import com.rewayaat.core.data.HadithObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -83,7 +84,10 @@ public class HadithPageController {
             return null;
         }
         try (ESClientProvider provider = new ESClientProvider()) {
-            var response = provider.client().get(g -> g.index(ESClientProvider.INDEX).id(narrationId), Map.class);
+            var response = provider.client().get(g -> g
+                    .index(ESClientProvider.INDEX)
+                    .id(narrationId)
+                    .sourceExcludes(HadithSourceFilter.excludes()), Map.class);
             if (!response.found() || response.source() == null) {
                 return null;
             }

--- a/src/main/java/com/rewayaat/controllers/rest/HadithController.java
+++ b/src/main/java/com/rewayaat/controllers/rest/HadithController.java
@@ -2,6 +2,7 @@ package com.rewayaat.controllers.rest;
 
 import com.rewayaat.config.ESClientProvider;
 import com.rewayaat.core.HadithObjectCollection;
+import com.rewayaat.core.HadithSourceFilter;
 import com.rewayaat.core.QueryMode;
 import com.rewayaat.core.QueryStringQueryResult;
 import com.rewayaat.core.UpdateRequest;
@@ -203,7 +204,9 @@ public class HadithController {
         if (narrationId.isEmpty()) {
             return badRequest("Narration id is required.");
         }
-        HadithObject existing = loadNarration(narrationId);
+        // The edit path re-indexes the whole document, so it must keep internal fields
+        // (semantic_vector) that are stripped from every response.
+        HadithObject existing = loadNarration(narrationId, true);
         if (existing == null) {
             return notFound("Narration not found.");
         }
@@ -352,12 +355,31 @@ public class HadithController {
     }
 
     private HadithObject loadNarration(String id) throws Exception {
+        return loadNarration(id, false);
+    }
+
+    /**
+     * Loads a narration by id.
+     *
+     * @param includeInternalFields when {@code true} the full {@code _source} is fetched,
+     *        including the {@code semantic_vector} dense vector. Only the edit path needs
+     *        this: it re-indexes the whole document, so dropping the vector would delete it
+     *        from Elasticsearch. Every response path must leave this {@code false} — see
+     *        {@link com.rewayaat.core.HadithSourceFilter}.
+     */
+    private HadithObject loadNarration(String id, boolean includeInternalFields) throws Exception {
         String narrationId = id == null ? "" : id.trim();
         if (narrationId.isEmpty()) {
             return null;
         }
         try (ESClientProvider provider = new ESClientProvider()) {
-            GetResponse<Map> response = provider.client().get(g -> g.index(ESClientProvider.INDEX).id(narrationId), Map.class);
+            GetResponse<Map> response = provider.client().get(g -> {
+                g.index(ESClientProvider.INDEX).id(narrationId);
+                if (!includeInternalFields) {
+                    g.sourceExcludes(HadithSourceFilter.excludes());
+                }
+                return g;
+            }, Map.class);
             if (!response.found() || response.source() == null) {
                 return null;
             }

--- a/src/main/java/com/rewayaat/core/DatabaseTopTerms.java
+++ b/src/main/java/com/rewayaat/core/DatabaseTopTerms.java
@@ -48,6 +48,7 @@ public class DatabaseTopTerms {
             SearchResponse<Map> response = provider.client().search(s -> s
                     .index(ESClientProvider.INDEX)
                     .query(prefixQuery)
+                    .source(HadithSourceFilter.searchSource())
                     .size(this.size * 10), // Fetch more docs to find unique terms
                     Map.class);
 

--- a/src/main/java/com/rewayaat/core/HadithSourceFilter.java
+++ b/src/main/java/com/rewayaat/core/HadithSourceFilter.java
@@ -1,0 +1,46 @@
+package com.rewayaat.core;
+
+import co.elastic.clients.elasticsearch.core.search.SourceConfig;
+
+import java.util.List;
+
+/**
+ * Central definition of hadith document fields that must never be fetched from
+ * Elasticsearch when the document is on its way to a client.
+ *
+ * <p>{@code semantic_vector} is a 1024-dimension dense vector used only for kNN
+ * scoring. A kNN query references the field by name in the query itself, which does
+ * not require the field to be present in {@code _source}, so excluding it here is
+ * safe for similarity search while removing roughly 12x of payload from every
+ * narration returned by the API.</p>
+ *
+ * <p>Note that {@link com.rewayaat.core.data.HadithObject} round-trips unknown fields
+ * through {@code @JsonAnySetter}/{@code @JsonAnyGetter}, so anything left in
+ * {@code _source} is serialised straight back out to the client. Filtering at the
+ * Elasticsearch level also saves the Elasticsearch-to-application transfer.</p>
+ *
+ * <p><strong>Do not</strong> use this filter on read paths that feed a write back into
+ * Elasticsearch (for example the narration edit endpoint, which re-indexes the whole
+ * document): dropping the vector there would delete it from the index.</p>
+ */
+public final class HadithSourceFilter {
+
+    /** Fields stripped from every hadith {@code _source} fetched for client consumption. */
+    public static final List<String> EXCLUDED_FIELDS = List.of("semantic_vector");
+
+    private static final SourceConfig SEARCH_SOURCE = SourceConfig.of(
+            s -> s.filter(f -> f.excludes(EXCLUDED_FIELDS)));
+
+    private HadithSourceFilter() {
+    }
+
+    /** Source configuration for search requests ({@code SearchRequest.Builder#source}). */
+    public static SourceConfig searchSource() {
+        return SEARCH_SOURCE;
+    }
+
+    /** Excluded field names for get/mget requests ({@code sourceExcludes}). */
+    public static List<String> excludes() {
+        return EXCLUDED_FIELDS;
+    }
+}

--- a/src/main/java/com/rewayaat/core/HadithSourceFilter.java
+++ b/src/main/java/com/rewayaat/core/HadithSourceFilter.java
@@ -11,8 +11,12 @@ import java.util.List;
  * <p>{@code semantic_vector} is a 1024-dimension dense vector used only for kNN
  * scoring. A kNN query references the field by name in the query itself, which does
  * not require the field to be present in {@code _source}, so excluding it here is
- * safe for similarity search while removing roughly 12x of payload from every
- * narration returned by the API.</p>
+ * safe for similarity search.</p>
+ *
+ * <p>Measured on the live index: a document fetched from Elasticsearch shrinks about
+ * 5x (26.5 KB to 4.8 KB for a single hit), and {@code /v1/narrations?q=prayer&per_page=5}
+ * drops from 149 KB to 41 KB -- roughly 3.6x, the gap between the two being response
+ * scaffolding and the fields the vector was dwarfing.</p>
  *
  * <p>Note that {@link com.rewayaat.core.data.HadithObject} round-trips unknown fields
  * through {@code @JsonAnySetter}/{@code @JsonAnyGetter}, so anything left in

--- a/src/main/java/com/rewayaat/core/HighlySignificantTerms.java
+++ b/src/main/java/com/rewayaat/core/HighlySignificantTerms.java
@@ -111,6 +111,7 @@ public class HighlySignificantTerms {
                     .index(ESClientProvider.INDEX)
                     .searchType(SearchType.DfsQueryThenFetch)
                     .size(sampleSize)
+                    .source(HadithSourceFilter.searchSource())
                     .query(query),
                     Map.class);
 

--- a/src/main/java/com/rewayaat/core/QueryStringQueryResult.java
+++ b/src/main/java/com/rewayaat/core/QueryStringQueryResult.java
@@ -199,6 +199,7 @@ public class QueryStringQueryResult implements RewayaatQueryResult {
                     }
                     return b;
                 }))
+                .source(HadithSourceFilter.searchSource())
                 .highlight(highlightBuilder)
                 .from(from)
                 .size(size)
@@ -243,6 +244,7 @@ public class QueryStringQueryResult implements RewayaatQueryResult {
                     // Note: No topic tag filters here - we want the base count
                     return b;
                 }))
+                .source(HadithSourceFilter.searchSource())
                 .from(0)
                 .size(0); // We only need the count, not actual results
 

--- a/src/main/java/com/rewayaat/core/SimilarHadithQueryResult.java
+++ b/src/main/java/com/rewayaat/core/SimilarHadithQueryResult.java
@@ -77,7 +77,10 @@ public class SimilarHadithQueryResult implements RewayaatQueryResult {
 
     private HadithObjectCollection semanticResult(ESClientProvider provider) {
         try {
-            GetResponse<Map> sourceResp = provider.client().get(g -> g.index(ESClientProvider.INDEX).id(hadithId), Map.class);
+            GetResponse<Map> sourceResp = provider.client().get(g -> g
+                    .index(ESClientProvider.INDEX)
+                    .id(hadithId)
+                    .sourceExcludes(HadithSourceFilter.excludes()), Map.class);
             if (!sourceResp.found() || sourceResp.source() == null) {
                 LOGGER.info("Semantic lookup skipped for id {} because source document was not found.", hadithId);
                 return null;
@@ -117,6 +120,9 @@ public class SimilarHadithQueryResult implements RewayaatQueryResult {
         return new SearchRequest.Builder()
                 .index(ESClientProvider.INDEX)
                 .size(poolSize)
+                // The kNN query below names semantic_vector in the *query*, which does not
+                // require the field to be present in _source, so it is safe to exclude it.
+                .source(HadithSourceFilter.searchSource())
                 .knn(buildSemanticKnnSearch(semanticText, poolSize, numCandidates))
                 .build();
     }

--- a/src/main/java/com/rewayaat/service/SimilarHadithService.java
+++ b/src/main/java/com/rewayaat/service/SimilarHadithService.java
@@ -6,6 +6,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.rewayaat.config.ESClientProvider;
 import com.rewayaat.core.HadithDisplaySegmenter;
 import com.rewayaat.core.HadithObjectCollection;
+import com.rewayaat.core.HadithSourceFilter;
 import com.rewayaat.core.data.HadithObject;
 import co.elastic.clients.elasticsearch.core.GetResponse;
 import co.elastic.clients.elasticsearch.core.MgetResponse;
@@ -72,7 +73,9 @@ public class SimilarHadithService {
         try (ESClientProvider provider = new ESClientProvider()) {
             // 1. Load source doc to get llm_similar field
             GetResponse<Map> sourceResp = provider.client().get(
-                    g -> g.index(ESClientProvider.INDEX).id(hadithId),
+                    g -> g.index(ESClientProvider.INDEX)
+                            .id(hadithId)
+                            .sourceExcludes(HadithSourceFilter.excludes()),
                     Map.class);
             if (!sourceResp.found() || sourceResp.source() == null) {
                 return null;
@@ -100,7 +103,9 @@ public class SimilarHadithService {
             // 3. Bulk-fetch the similar hadith docs
             List<String> ids = entries.stream().map(e -> e.id).toList();
             MgetResponse<Map> mgetResponse = provider.client().mget(
-                    r -> r.index(ESClientProvider.INDEX).ids(ids),
+                    r -> r.index(ESClientProvider.INDEX)
+                            .ids(ids)
+                            .sourceExcludes(HadithSourceFilter.excludes()),
                     Map.class);
 
             // 4. Build HadithObject list, preserving order

--- a/src/main/java/com/rewayaat/service/UserCollectionService.java
+++ b/src/main/java/com/rewayaat/service/UserCollectionService.java
@@ -8,6 +8,7 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rewayaat.config.ESClientProvider;
 import com.rewayaat.core.HadithObjectCollection;
+import com.rewayaat.core.HadithSourceFilter;
 import com.rewayaat.core.data.HadithObject;
 import com.rewayaat.core.data.UserCollection;
 import org.slf4j.Logger;
@@ -219,6 +220,7 @@ public class UserCollectionService {
             SearchResponse<Map> response = provider.client().search(s -> s
                     .index(ESClientProvider.INDEX)
                     .size(hadithIds.size())
+                    .source(HadithSourceFilter.searchSource())
                     .query(q -> q.ids(ids -> ids.values(hadithIds))), Map.class);
             for (Hit<Map> hit : response.hits().hits()) {
                 if (hit.source() == null) {

--- a/src/test/java/com/rewayaat/integration/HadithApiIntegrationTest.java
+++ b/src/test/java/com/rewayaat/integration/HadithApiIntegrationTest.java
@@ -118,6 +118,38 @@ class HadithApiIntegrationTest extends ElasticsearchTestSupport {
         assertNotNull(body.get("collection"));
     }
 
+    @Test
+    void narrationResponses_neverExposeSemanticVector() throws Exception {
+        indexDoc("4", "{\"english\":\"hello vector\",\"arabic\":\"سلام\",\"book\":\"Book D\","
+                + "\"semantic_vector\":[0.1,0.2,0.3],"
+                + "\"llm_similar\":[{\"id\":\"1\",\"match_type\":\"wording\",\"reason\":\"same wording\"}]}");
+
+        // The vector really is stored, so the assertions below prove it is filtered out on
+        // the way to the client rather than simply absent from the document.
+        assertTrue(client.get(g -> g.index(INDEX).id("4"), Map.class).source().containsKey("semantic_vector"));
+
+        ResponseEntity<String> search = restTemplate.getForEntity("/v1/narrations?q=vector", String.class);
+        assertEquals(HttpStatus.OK, search.getStatusCode());
+        assertNotNull(search.getBody());
+        assertTrue(search.getBody().contains("Book D"));
+        assertFalse(search.getBody().contains("semantic_vector"));
+
+        ResponseEntity<String> byId = restTemplate.getForEntity("/v1/narrations/4", String.class);
+        assertEquals(HttpStatus.OK, byId.getStatusCode());
+        assertNotNull(byId.getBody());
+        assertTrue(byId.getBody().contains("Book D"));
+        assertFalse(byId.getBody().contains("semantic_vector"));
+
+        ResponseEntity<String> similar = restTemplate.getForEntity("/v1/narrations/similar?id=4&per_page=5", String.class);
+        assertEquals(HttpStatus.OK, similar.getStatusCode());
+        assertNotNull(similar.getBody());
+        // Similar-hadith lookup still resolves the pre-computed match...
+        assertTrue(similar.getBody().contains("\"_id\":\"1\""));
+        assertTrue(similar.getBody().contains("wording"));
+        // ...without leaking the vector.
+        assertFalse(similar.getBody().contains("semantic_vector"));
+    }
+
     private void indexDoc(String id, String json) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> doc = mapper.readValue(json, new TypeReference<Map<String, Object>>() {


### PR DESCRIPTION
## The problem

Every hadith document in `rewayaat_updated` carries `semantic_vector` — a 1024-dimension `dense_vector` (int8_hnsw, cosine) used for kNN similarity scoring. No API client needs it, but nothing filtered it out:

1. `QueryStringQueryResult.buildSearchRequest()` set no `_source` filter, so Elasticsearch returned the whole document.
2. `processHit()` copied the entire `hit.source()` map into the object.
3. `HadithObject` has `@JsonAnySetter`/`@JsonAnyGetter` on `additionalProperties`, so unknown fields were serialised straight back out — the `@JsonIgnore` on the field itself never applied, because `semantic_vector` is not a declared field.

This confirms and closes the open question raised in #66 ("Confirm whether `/v1/narrations` actually serialises `semantic_vector`"): it did, on every response.

## The fix

Filtering happens at the Elasticsearch `_source` level rather than after the fact, so the vector is never transferred from Elasticsearch either. The exclusion list lives in one place — `HadithSourceFilter` (`core/HadithSourceFilter.java`) — which exposes a `SourceConfig` for search requests and a `List<String>` for get/mget.

Applied to every read path that can reach a client:

| Path | Change |
|---|---|
| `QueryStringQueryResult` | `.source(...)` on `buildSearchRequest` and `buildBaseSearchRequest` |
| `SimilarHadithQueryResult` | `sourceExcludes` on the source lookup, `.source(...)` on the kNN search |
| `SimilarHadithService` | `sourceExcludes` on the source get and on the bulk `mget` |
| `UserCollectionService.collectionHadith` | `.source(...)` on the ids search |
| `HadithController` `/v1/narrations/{id}` | `sourceExcludes` on `loadNarration` |
| `HadithPageController` | `sourceExcludes` on the server-rendered hadith page |
| `HighlySignificantTerms`, `DatabaseTopTerms` | `.source(...)` — these sampled up to 500 full documents per request purely to count terms |

Already fine, left alone: `/v1/narrations/page_for_id` (`_source: false`), `SitemapController` (`_source: false`), `BrowseFacets` (`size: 0`, aggregations only), `QuranicInsightsService` (different index — `rewayaat_quranic_light_filtered` has no vector field).

### One deliberate exception

`PUT /v1/narrations/{id}` re-indexes the whole document (`UpdateRequest` does a full `index`, not a partial update). Stripping the vector on the read side of that flow would **delete it from Elasticsearch** on every edit. `loadNarration` therefore takes an explicit `includeInternalFields` flag, and only the edit path passes `true`.

For the same reason the filter is applied at the query level and *not* inside `HadithObject`'s `@JsonAnyGetter` — that getter is also how the document is written back.

## Measured results

Real byte counts, uncompressed, same requests against the live index (32,519 docs), master build vs. this branch:

| Endpoint | Before | After | |
|---|---:|---:|---|
| `/v1/narrations?q=prayer&per_page=5` | 149,316 B | 40,949 B | **3.6x** |
| `/v1/narrations?q=prayer&per_page=20` (default page) | 591,637 B | 157,876 B | **3.7x** |
| `/v1/narrations/{id}` | 27,947 B | 6,265 B | **4.5x** |
| `/v1/narrations/similar?id={id}` | 115,223 B | 28,535 B | **4.0x** |
| 6 queries × 20 results, aggregate | 3,552,105 B | 949,860 B | **3.7x** |
| `/similar?all=true` across 30 hadith ids, aggregate | 3,854,650 B | 1,252,457 B | **3.1x** |

Elasticsearch → app transfer, for the 500-document sample that `/v1/terms/significant` takes on every call: **12,877,884 B → 2,034,976 B (6.3x)**.

`semantic_vector` now appears in zero API response bodies (search, by-id, similar, quranic insights, the rendered hadith page).

## Verification

- **`mvn test`: 414/414 green** on this branch, including a new regression test (`HadithApiIntegrationTest#narrationResponses_neverExposeSemanticVector`) that seeds a document with a real `semantic_vector`, asserts the vector *is* in Elasticsearch, and then asserts it is absent from the search, by-id and similar responses while the similar match still resolves.
  - Note: `ElasticsearchTestSupport` is flaky against a multi-node cluster — if a `rewayaat` index is left behind by an aborted run, `indices.exists` can return a stale `false` and the following `create` fails with `resource_already_exists_exception`. This reproduces identically on `master` (3 failures / 3 errors there on the same box) and is unrelated to this change; deleting the leftover index before the run makes it green.

- **Similar-hadith is unchanged.** `/v1/narrations/similar?id=...&all=true` was compared before vs. after across **30 hadith ids** spanning five queries: every response is byte-identical once `semantic_vector` is removed — same ids, same order, same `matchType`, same `matchReason`, same 7 empty result sets on both sides.

- **kNN does not need the vector in `_source`**, verified directly against the live index with a real 1024-dim query vector:

  ```
  kNN hits (full _source)     : [(…:990, 0.99957466), (…:1065, 0.91340685), (…:1087, 0.90039325), …]
  kNN hits (_source excluded) : [(…:990, 0.99957466), (…:1065, 0.91340685), (…:1087, 0.90039325), …]
  SAME HITS AND SCORES: True
  ```

- **The edit path still sees the vector.** A get without `_source_excludes` still carries `semantic_vector`; with the exclusion the payload is identical apart from that one field.

- **No other endpoint changed.** `/v1/terms/top`, `/v1/terms/significant`, `/v1/browse/books`, `/v1/browse/facets`, `/v1/narrations/page_for_id`, `/v1/narrations/quranic_insights` and the rendered `/hadith/{id}` page are all byte-identical before vs. after.

## Out of scope, flagged for a separate decision

Deliberately **not** touched, per scope: `semantic_matn_source`, `semantic_english_hint_source`, `semantic_significant_terms_source`.

Worth a look though — `grep` finds no reference to any of them (nor to `semantic_vector`) anywhere in `templates/` or `static/`, so the frontend appears not to use them. In the now-slimmer 5-result response they cost:

| Field | Share of response |
|---|---:|
| `llm_similar` | 19.2% |
| `semantic_matn_source` | 7.4% |
| `semantic_english_hint_source` | 1.4% |

`llm_similar` is the bigger remaining item — the full pre-computed similar-pair list ships on every hadith in every search result, even though it is only consumed by `/similar`. Both are separate judgement calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017H2pVwWfyUkFmTSk8VrqUZ
