### PR TITLE
Fix the sitemap: it listed none of the 32,519 hadith pages

### DIFF
--- a/src/main/java/com/rewayaat/controllers/SitemapController.java
+++ b/src/main/java/com/rewayaat/controllers/SitemapController.java
@@ -1,11 +1,14 @@
 package com.rewayaat.controllers;
 
 import com.rewayaat.config.ESClientProvider;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -27,7 +30,7 @@ public class SitemapController {
     private static final Logger LOGGER = LoggerFactory.getLogger(SitemapController.class);
     private static final String BASE_URL = "https://hadith.academyofislam.com";
     private static final int PAGE_SIZE = 10000;
-    private static final int ES_MAX_RESULT_WINDOW = 10000;
+    private static final String PIT_KEEP_ALIVE = "2m";
 
     @RequestMapping(value = "/sitemap.xml", method = RequestMethod.GET, produces = MediaType.APPLICATION_XML_VALUE)
     public ResponseEntity<String> sitemapIndex() {
@@ -91,7 +94,11 @@ public class SitemapController {
                 appendUrl(xml, "/hadith/" + escapeXml(id), "0.8", "monthly");
             }
         } catch (Exception e) {
+            // Serving an empty urlset with a 200 tells crawlers there is nothing
+            // here, which is how a broken query went unnoticed. A 5xx tells them
+            // to retry and to keep the sitemap they already have.
             LOGGER.error("Error fetching hadith IDs for sitemap page {}", page, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
 
         xml.append("</urlset>");
@@ -101,52 +108,69 @@ public class SitemapController {
     }
 
     /**
-     * Fetches hadith IDs for a given sitemap page using search_after pagination.
+     * Fetches the hadith IDs belonging to one sitemap page.
+     *
+     * <p>Paging is done against a point-in-time so the view of the index stays
+     * fixed for the whole walk, with {@code _shard_doc} as the cursor. Sorting on
+     * {@code _id} would be the obvious choice, but Elasticsearch has disallowed
+     * fielddata access on that field since 8.x, and the resulting error was being
+     * swallowed into an empty sitemap.
      */
-    private List<String> fetchHadithIds(int page) throws Exception {
+    private List<String> fetchHadithIds(int page) throws IOException {
         try (ESClientProvider provider = new ESClientProvider()) {
-            List<String> allIds = new ArrayList<>();
-            String searchAfter = null;
+            ElasticsearchClient client = provider.client();
+            String pitId = client.openPointInTime(p -> p
+                    .index(ESClientProvider.INDEX)
+                    .keepAlive(t -> t.time(PIT_KEEP_ALIVE))).id();
 
-            // We need to walk through pages of 10K to reach the desired offset,
-            // then return the IDs for that page.
-            for (int current = 1; current <= page; current++) {
-                final String afterValue = searchAfter;
-                SearchResponse<Void> response = provider.client().search(s -> {
-                    s.index(ESClientProvider.INDEX)
-                            .size(PAGE_SIZE)
-                            .source(src -> src.fetch(false))
-                            .sort(so -> so.field(f -> f.field("_id").order(SortOrder.Asc)));
-                    if (afterValue != null) {
-                        s.searchAfter(afterValue);
+            try {
+                List<FieldValue> cursor = null;
+
+                // Walk forward a page at a time until we reach the one asked for.
+                for (int current = 1; current <= page; current++) {
+                    final List<FieldValue> after = cursor;
+                    SearchResponse<Void> response = client.search(s -> {
+                        s.pit(p -> p.id(pitId).keepAlive(t -> t.time(PIT_KEEP_ALIVE)))
+                                .size(PAGE_SIZE)
+                                .trackTotalHits(t -> t.enabled(false))
+                                .source(src -> src.fetch(false))
+                                .sort(so -> so.field(f -> f.field("_shard_doc").order(SortOrder.Asc)));
+                        if (after != null) {
+                            s.searchAfter(after);
+                        }
+                        return s;
+                    }, Void.class);
+
+                    List<Hit<Void>> hits = response.hits().hits();
+                    if (hits.isEmpty()) {
+                        return List.of();
                     }
-                    return s;
-                }, Void.class);
-
-                List<Hit<Void>> hits = response.hits().hits();
-                if (hits.isEmpty()) {
-                    break;
+                    if (current == page) {
+                        return hits.stream().map(Hit::id).toList();
+                    }
+                    cursor = hits.get(hits.size() - 1).sort();
                 }
 
-                if (current == page) {
-                    for (Hit<Void> hit : hits) {
-                        allIds.add(hit.id());
-                    }
-                } else {
-                    searchAfter = hits.get(hits.size() - 1).id();
+                return List.of();
+            } finally {
+                try {
+                    client.closePointInTime(c -> c.id(pitId));
+                } catch (Exception e) {
+                    // The point-in-time expires on its own; never mask a real failure.
+                    LOGGER.warn("Could not close sitemap point-in-time", e);
                 }
             }
-
-            return allIds;
         }
     }
 
     private long totalHadithCount() {
         try (ESClientProvider provider = new ESClientProvider()) {
-            SearchResponse<Void> response = provider.client().search(s -> {
-                s.index(ESClientProvider.INDEX).size(0);
-                return s;
-            }, Void.class);
+            // Without trackTotalHits the count saturates at 10,000, which
+            // silently truncated the sitemap index to a single page.
+            SearchResponse<Void> response = provider.client().search(s -> s
+                    .index(ESClientProvider.INDEX)
+                    .size(0)
+                    .trackTotalHits(t -> t.enabled(true)), Void.class);
             return response.hits().total().value();
         } catch (IOException e) {
             LOGGER.error("Error counting hadith for sitemap", e);


### PR DESCRIPTION
`/sitemap-hadith-1.xml` in production has been serving an empty urlset:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
</urlset>
```

So of 32,519 hadith pages, crawlers were being offered **none** — just the home page and search tips. All the SEO work on the detail pages was invisible.

Two independent causes, both reproduced against production Elasticsearch.

### 1. Sorting on `_id` is rejected by Elasticsearch

`fetchHadithIds` sorted on `_id`. Running that query directly:

> `illegal_argument_exception: Fielddata access on the _id field is disallowed, you can re-enable it by updating the dynamic cluster setting: indices.id_field_data.enabled`

The exception was caught and logged, so the endpoint returned `200` with an empty urlset instead of failing.

Paging now runs against a point-in-time with `_shard_doc` as the cursor — the supported way to deep-paginate — which also keeps the view of the index fixed for the whole walk rather than shifting under concurrent writes.

### 2. The total count saturated at 10,000

`totalHadithCount` omitted `track_total_hits`:

```
without:  {'value': 10000, 'relation': 'gte'}
with:     {'value': 32519, 'relation': 'eq'}
```

`ceil(10000/10000) = 1`, so the index advertised one hadith sitemap instead of the four needed.

### 3. Failures are no longer silent

A failed page returns `500` rather than an empty urlset. An empty sitemap tells a crawler there is nothing to index — exactly how this stayed invisible; a 5xx tells it to retry and keep the sitemap it already has. Verified by killing the ES connection: the endpoint returns `500` with an empty body rather than a well-formed, empty, misleading `200`.

### Verification

Run against production Elasticsearch:

| page | status | URLs |
|---|---|---|
| `sitemap-hadith-1.xml` | 200 | 10,000 |
| `sitemap-hadith-2.xml` | 200 | 10,000 |
| `sitemap-hadith-3.xml` | 200 | 10,000 |
| `sitemap-hadith-4.xml` | 200 | 2,519 |
| **total** | | **32,519** — matches the index exactly |

- All 32,519 URLs unique (no page overlap or gap in the walk).
- All four documents parse as well-formed XML.
- A random sample of 20 URLs all resolve `200`.
- The sitemap index now lists four hadith sitemaps.
- 406 tests pass.

Note: the URLs still carry `hadith.academyofislam.com`, which is the separate canonical-domain question — deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zydKqES7EACatiDK2f721