### PR TITLE
Fix soft 404s, fabricated lastmod, and indexable helper pages

### DIFF
--- a/src/main/java/com/rewayaat/config/CrawlerDirectivesConfig.java
+++ b/src/main/java/com/rewayaat/config/CrawlerDirectivesConfig.java
@@ -1,0 +1,41 @@
+package com.rewayaat.config;
+
+import java.util.List;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Marks the pages that serve a purpose but should never appear in search results.
+ *
+ * <p>{@code welcome.html} is a fragment the home page pulls in over XHR — it has no
+ * {@code <html>}, {@code <head>} or {@code <title>} — yet it answers 200 on its own
+ * URL, so a crawler can index it as a thin duplicate of the home page hero. The
+ * {@code error/*} pages are reachable directly for the same reason.
+ *
+ * <p>Both are handled with a header rather than a {@code Disallow} in robots.txt,
+ * because Disallow is the wrong tool twice over here: Googlebot renders the home
+ * page and fetches the fragment while doing so, so blocking it would hide the hero
+ * from the index, and a blocked URL can still be indexed from a link — a crawler
+ * that cannot fetch the page never sees the noindex telling it to stay away.
+ */
+@Configuration
+public class CrawlerDirectivesConfig {
+
+    private static final List<String> NOINDEX_PATHS = List.of("/welcome.html", "/error/*");
+
+    @Bean
+    public FilterRegistrationBean<Filter> noindexFilter() {
+        Filter filter = (request, response, chain) -> {
+            ((HttpServletResponse) response).setHeader("X-Robots-Tag", "noindex");
+            chain.doFilter(request, response);
+        };
+        FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>(filter);
+        NOINDEX_PATHS.forEach(registration::addUrlPatterns);
+        return registration;
+    }
+}

--- a/src/main/java/com/rewayaat/controllers/HadithPageController.java
+++ b/src/main/java/com/rewayaat/controllers/HadithPageController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -30,11 +31,15 @@ public class HadithPageController {
     private static final String BASE_URL = "https://hadith.academyofislam.com";
 
     @RequestMapping(value = "/{id}", method = RequestMethod.GET)
-    public String hadithPage(@PathVariable("id") String id, Model model, HttpServletResponse response) {
+    public String hadithPage(@PathVariable("id") String id, Model model, HttpServletResponse response)
+            throws IOException {
         HadithObject hadith = loadNarration(id);
         if (hadith == null) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            return "redirect:/error/404.html";
+            // sendError runs the container's error dispatch, which serves
+            // static/error/404.html under a real 404. Redirecting there instead
+            // answered 302 -> 200, which crawlers read as a soft 404.
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return null;
         }
 
         // Split chain from matn using the display segmenter

--- a/src/main/java/com/rewayaat/controllers/SitemapController.java
+++ b/src/main/java/com/rewayaat/controllers/SitemapController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,14 +44,12 @@ public class SitemapController {
         // Static pages sitemap
         xml.append("  <sitemap>\n");
         xml.append("    <loc>").append(BASE_URL).append("/sitemap-static.xml</loc>\n");
-        xml.append("    <lastmod>").append(LocalDate.now()).append("</lastmod>\n");
         xml.append("  </sitemap>\n");
 
         // Hadith sitemap pages
         for (int i = 1; i <= totalPages; i++) {
             xml.append("  <sitemap>\n");
             xml.append("    <loc>").append(BASE_URL).append("/sitemap-hadith-").append(i).append(".xml</loc>\n");
-            xml.append("    <lastmod>").append(LocalDate.now()).append("</lastmod>\n");
             xml.append("  </sitemap>\n");
         }
 
@@ -69,6 +66,7 @@ public class SitemapController {
         xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
 
         appendUrl(xml, "/", "1.0", "weekly");
+        appendUrl(xml, "/updates.html", "0.6", "weekly");
         appendUrl(xml, "/search_tips.html", "0.5", "monthly");
 
         xml.append("</urlset>");
@@ -178,10 +176,18 @@ public class SitemapController {
         }
     }
 
+    /**
+     * Writes one {@code <url>} entry.
+     *
+     * <p>No {@code <lastmod>}: nothing in the index records when a narration was last
+     * edited, and the previous code emitted {@code LocalDate.now()} — telling crawlers
+     * that all 32,519 pages had changed today, every day. Search engines discount a
+     * lastmod they can see is unreliable, so omitting it beats fabricating it. If an
+     * updated-at field is ever added to the index, it belongs here.
+     */
     private void appendUrl(StringBuilder xml, String path, String priority, String changefreq) {
         xml.append("  <url>\n");
         xml.append("    <loc>").append(BASE_URL).append(path).append("</loc>\n");
-        xml.append("    <lastmod>").append(LocalDate.now()).append("</lastmod>\n");
         xml.append("    <changefreq>").append(changefreq).append("</changefreq>\n");
         xml.append("    <priority>").append(priority).append("</priority>\n");
         xml.append("  </url>\n");


### PR DESCRIPTION
The five follow-ups found while auditing the sitemap fix. The canonical domain stays `hadith.academyofislam.com` — untouched.

### 1. `lastmod` was fabricated

`appendUrl` emitted `LocalDate.now()`, so all 32,519 URLs claimed to have been modified today — and would again tomorrow. Search engines discount a `lastmod` they can see is unreliable, so the field was doing harm rather than nothing.

Nothing in the index records when a narration was edited, so it is now omitted rather than invented. If an updated-at field is added later, the javadoc says where it goes.

### 2. Soft 404 on a missing hadith

A bad ID answered `302 → /error/404.html → 200`. A crawler reads a redirect to a successful page as a soft 404: the error page gets indexed and crawl budget is spent rediscovering it.

`response.sendError(SC_NOT_FOUND)` now runs the container's error dispatch, which serves the same page under a real 404.

```
before:  302  ->  https://rewayaat.info/error/404.html  (200)
after:   404, 0 redirects, text/html, <title>404 Page Not Found</title>
```

Browsers and Googlebot send `Accept: text/html` and get the styled error page; API-style clients keep the existing JSON envelope through normal content negotiation.

### 3. `/updates.html` was missing from the sitemap

It is linked from the nav on every page, but `sitemap-static.xml` listed only `/` and `/search_tips.html`.

### 4 & 5. `welcome.html` and the error pages were indexable

`welcome.html` is a fragment the home page pulls in over XHR — no `<html>`, `<head>` or `<title>` — yet it answers 200 on its own URL, so it can be indexed as a thin duplicate of the home page hero. The `error/*` pages are directly reachable for the same reason.

Both now send `X-Robots-Tag: noindex`.

**Deliberately not a robots.txt `Disallow`**, which would be the wrong tool twice over:

- Googlebot renders the home page and fetches `welcome.html` while doing so. Blocking it would hide the hero content from the index.
- A blocked URL can still be indexed from a link — a crawler that cannot fetch the page never sees the noindex telling it to stay away. Disallow and noindex work against each other.

### Verification

Run against production Elasticsearch:

| check | result |
|---|---|
| `<lastmod>` in hadith sitemap / index | 0 / 0 |
| sitemap total | 10000 + 10000 + 10000 + 2519 = **32,519**, still complete |
| XML validity | index and pages all parse |
| `/updates.html` in static sitemap | present |
| missing hadith | `404`, 0 redirects, styled error page |
| `X-Robots-Tag` on `/welcome.html`, `/error/404.html`, `/error/500.html` | `noindex` |
| `X-Robots-Tag` on `/`, `/updates.html`, `/search_tips.html`, a hadith page, `/sitemap.xml` | absent — real pages stay indexable |

406 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zydKqES7EACatiDK2f721