### PR TITLE
Add Google Search Console verification file

### DIFF
--- a/src/main/resources/static/google6d32eeb8012f86c4.html
+++ b/src/main/resources/static/google6d32eeb8012f86c4.html
@@ -1,0 +1,1 @@
+google-site-verification: google6d32eeb8012f86c4.html


### PR DESCRIPTION
Verifies ownership of the `hadith.academyofislam.com` URL-prefix property so the sitemap can be submitted.

Google fetches `https://hadith.academyofislam.com/google6d32eeb8012f86c4.html` and matches the one-line body against the filename. The token is public by design — it proves control of the server, and is meant to be fetchable by anyone.

Served from the static root, so it covers all three hostnames the app answers on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zydKqES7EACatiDK2f721