### PR TITLE
SEO: give the 32,519 narration pages an internal link graph, and target "shia hadith" on the home page

### DIFF
--- a/src/main/java/com/rewayaat/config/CrawlerDirectivesConfig.java
+++ b/src/main/java/com/rewayaat/config/CrawlerDirectivesConfig.java
@@ -12,21 +12,21 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Marks the pages that serve a purpose but should never appear in search results.
  *
- * <p>{@code welcome.html} is a fragment the home page pulls in over XHR — it has no
- * {@code <html>}, {@code <head>} or {@code <title>} — yet it answers 200 on its own
- * URL, so a crawler can index it as a thin duplicate of the home page hero. The
- * {@code error/*} pages are reachable directly for the same reason.
+ * <p>The {@code error/*} pages are reachable on their own URLs and answer 200 there, so
+ * a crawler can index them as thin content.
  *
- * <p>Both are handled with a header rather than a {@code Disallow} in robots.txt,
- * because Disallow is the wrong tool twice over here: Googlebot renders the home
- * page and fetches the fragment while doing so, so blocking it would hide the hero
- * from the index, and a blocked URL can still be indexed from a link — a crawler
- * that cannot fetch the page never sees the noindex telling it to stay away.
+ * <p>Handled with a header rather than a {@code Disallow} in robots.txt, because a
+ * blocked URL can still be indexed from a link — a crawler that cannot fetch the page
+ * never sees the noindex telling it to stay away.
+ *
+ * <p>{@code welcome.html} used to be listed here too. It was the home page body, pulled
+ * in over XHR, which is why the home page served no content to a crawler; the body is
+ * rendered by the server now and the file is gone.
  */
 @Configuration
 public class CrawlerDirectivesConfig {
 
-    private static final List<String> NOINDEX_PATHS = List.of("/welcome.html", "/error/*");
+    private static final List<String> NOINDEX_PATHS = List.of("/error/*");
 
     @Bean
     public FilterRegistrationBean<Filter> noindexFilter() {

--- a/src/main/java/com/rewayaat/controllers/BookBlurbs.java
+++ b/src/main/java/com/rewayaat/controllers/BookBlurbs.java
@@ -1,0 +1,52 @@
+package com.rewayaat.controllers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rewayaat.service.BookCatalog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The descriptive blurbs already shipped for the search UI, keyed so a book page can use them.
+ *
+ * <p>{@code book_blurbs.json} spells its books differently from Elasticsearch — "AL-KAFI"
+ * against "Al-Kāfi", "Nahj Al-Balagha" against "Nahj al-Balāgha" — so the two are matched on
+ * the same slug the URLs use, which folds away case and the transliteration diacritics.
+ * A book with no blurb simply renders without one.
+ */
+class BookBlurbs {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BookBlurbs.class);
+
+    private final Map<String, String> bySlug;
+
+    BookBlurbs() {
+        this.bySlug = load();
+    }
+
+    String forSlug(String slug) {
+        return bySlug.get(slug);
+    }
+
+    private static Map<String, String> load() {
+        Map<String, String> loaded = new LinkedHashMap<>();
+        try (InputStream in = new ClassPathResource("static/book_blurbs.json").getInputStream()) {
+            JsonNode root = new ObjectMapper().readTree(in);
+            for (JsonNode entry : root) {
+                String book = entry.path("book").asText("");
+                String blurb = entry.path("blurb").asText("");
+                if (!book.isBlank() && !blurb.isBlank()) {
+                    loaded.put(BookCatalog.slugify(book), blurb);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Could not read book_blurbs.json; book pages will render without blurbs", e);
+        }
+        return Map.copyOf(loaded);
+    }
+}

--- a/src/main/java/com/rewayaat/controllers/BookPageController.java
+++ b/src/main/java/com/rewayaat/controllers/BookPageController.java
@@ -5,6 +5,7 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rewayaat.config.ESClientProvider;
+import com.rewayaat.core.HadithDisplaySegmenter;
 import com.rewayaat.service.BookCatalog;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletResponse;
@@ -204,7 +205,7 @@ public class BookPageController {
                 row.put("id", hit.id());
                 row.put("url", "/hadith/" + hit.id());
                 row.put("number", str(source.get("number")));
-                row.put("excerpt", excerpt(str(source.get("english"))));
+                row.put("excerpt", excerpt(matn(source)));
                 results.add(row);
             }
         }
@@ -235,6 +236,27 @@ public class BookPageController {
     /** Volume labels are free text in the index, so they cannot go into a path raw. */
     private static String encode(String segment) {
         return URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    /**
+     * The narration itself, with the chain of transmission stripped.
+     *
+     * <p>Excerpting the raw English would open every entry with its isnad — "A number of
+     * our people have narrated from…" — which is near-identical boilerplate across
+     * thousands of narrations, and would make every chapter page look like a page of
+     * duplicates to a reader and to a crawler alike.
+     */
+    private static String matn(Map<String, Object> source) {
+        Map<String, Object> segmented = new LinkedHashMap<>();
+        segmented.put("english", source.get("english"));
+        segmented.put("arabic", source.get("arabic"));
+        try {
+            HadithDisplaySegmenter.enrich(segmented);
+        } catch (Exception e) {
+            LOGGER.debug("Could not segment a narration for its excerpt", e);
+        }
+        String content = str(segmented.getOrDefault("englishContent", ""));
+        return content.isBlank() ? str(source.get("english")) : content;
     }
 
     private static String str(Object value) {

--- a/src/main/java/com/rewayaat/controllers/BookPageController.java
+++ b/src/main/java/com/rewayaat/controllers/BookPageController.java
@@ -1,0 +1,339 @@
+package com.rewayaat.controllers;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rewayaat.config.ESClientProvider;
+import com.rewayaat.service.BookCatalog;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Server-rendered book and chapter pages.
+ *
+ * <p>These are the pages the site was missing entirely. Without them nothing stood
+ * between the home page and 32,519 narration pages: no URL could rank for a book or
+ * chapter name, and the narrations themselves were reachable only from the XML sitemap,
+ * so no internal link reached any of them. Every page here is plain server-rendered
+ * HTML with real {@code <a href>} links, because the rest of the site renders its
+ * content over XHR and a crawler that does not run scripts sees none of it.
+ */
+@Hidden
+@Controller
+public class BookPageController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BookPageController.class);
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String BASE_URL = HomeController.BASE_URL;
+
+    /** Enough to be a useful chapter page without turning one into a 500-narration wall. */
+    private static final int MAX_CHAPTER_NARRATIONS = 500;
+    private static final int EXCERPT_CHARS = 220;
+
+    private final BookCatalog catalog;
+    private final BookBlurbs blurbs = new BookBlurbs();
+
+    public BookPageController(BookCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @GetMapping("/books")
+    public String booksIndex(Model model) {
+        List<BookCatalog.Book> books = catalog.books();
+
+        model.addAttribute("books", books);
+        model.addAttribute("totalNarrations", books.stream().mapToLong(BookCatalog.Book::count).sum());
+        model.addAttribute("seoTitle", "Shia Hadith Books — Al-Kafi, Nahj al-Balagha and More");
+        model.addAttribute("seoDescription",
+                "Browse the primary Shia hadith collections: Al-Kafi, Nahj al-Balagha, "
+                + "Man La Yahduruh al-Faqih, Al-Khisal, Al-Amali and more, in Arabic and English.");
+        model.addAttribute("canonicalUrl", BASE_URL + "/books");
+        model.addAttribute("jsonLd", booksIndexJsonLd(books));
+        addBreadcrumbs(model, new LinkedHashMap<>());
+        return "books";
+    }
+
+    @GetMapping("/books/{bookSlug}")
+    public String bookPage(@PathVariable String bookSlug, Model model, HttpServletResponse response)
+            throws IOException {
+        Optional<BookCatalog.Book> found = catalog.book(bookSlug);
+        if (found.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return null;
+        }
+        BookCatalog.Book book = found.get();
+
+        // Al-Kafi alone has 2,693 chapters. Listing every one of them on the book page
+        // made it a 637KB document with 2,693 outbound links — slow on mobile and a
+        // thin spread of link equity. Where a book has volumes, they become the level
+        // in between, so no page in the chain carries more than a few hundred links.
+        List<String> volumes = book.volumes();
+        model.addAttribute("book", book);
+        model.addAttribute("volumes", volumes.stream()
+                .map(v -> Map.of(
+                        "label", "Volume " + v,
+                        "url", "/books/" + bookSlug + "/volume/" + encode(v),
+                        "chapterCount", book.chaptersInVolume(v).size()))
+                .toList());
+        model.addAttribute("chapters", volumes.isEmpty() ? book.chapters() : List.of());
+        model.addAttribute("blurb", blurbs.forSlug(bookSlug));
+        model.addAttribute("seoTitle", book.name() + " — Shia Hadith in Arabic & English");
+        model.addAttribute("seoDescription", String.format(
+                "Read %s in Arabic and English: %,d narrations across %,d chapters, "
+                + "with similar narrations and Quranic insights for each hadith.",
+                book.name(), book.count(), book.chapters().size()));
+        model.addAttribute("canonicalUrl", BASE_URL + "/books/" + bookSlug);
+        model.addAttribute("jsonLd", bookJsonLd(book));
+        LinkedHashMap<String, String> trail = new LinkedHashMap<>();
+        trail.put(book.name(), "/books/" + bookSlug);
+        addBreadcrumbs(model, trail);
+        return "book";
+    }
+
+    @GetMapping("/books/{bookSlug}/volume/{volume}")
+    public String volumePage(@PathVariable String bookSlug, @PathVariable String volume,
+                             Model model, HttpServletResponse response) throws IOException {
+        Optional<BookCatalog.Book> found = catalog.book(bookSlug);
+        if (found.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return null;
+        }
+        BookCatalog.Book book = found.get();
+        List<BookCatalog.Chapter> chapters = book.chaptersInVolume(volume);
+        if (chapters.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return null;
+        }
+        String label = "Volume " + volume;
+        long narrations = chapters.stream().mapToLong(BookCatalog.Chapter::count).sum();
+
+        model.addAttribute("book", book);
+        model.addAttribute("volumeLabel", label);
+        model.addAttribute("chapters", chapters);
+        model.addAttribute("volumes", List.of());
+        model.addAttribute("narrationCount", narrations);
+        model.addAttribute("seoTitle", book.name() + " " + label + " — Shia Hadith in Arabic & English");
+        model.addAttribute("seoDescription", String.format(
+                "%s, %s: %,d narrations across %,d chapters, in Arabic and English.",
+                book.name(), label, narrations, chapters.size()));
+        model.addAttribute("canonicalUrl", BASE_URL + "/books/" + bookSlug + "/volume/" + encode(volume));
+
+        LinkedHashMap<String, String> trail = new LinkedHashMap<>();
+        trail.put(book.name(), "/books/" + bookSlug);
+        trail.put(label, "/books/" + bookSlug + "/volume/" + encode(volume));
+        addBreadcrumbs(model, trail);
+        model.addAttribute("jsonLd", bookJsonLd(book));
+        return "volume";
+    }
+
+    @GetMapping("/books/{bookSlug}/{chapterSlug}")
+    public String chapterPage(@PathVariable String bookSlug, @PathVariable String chapterSlug,
+                              Model model, HttpServletResponse response) throws IOException {
+        Optional<BookCatalog.Chapter> found = catalog.chapter(bookSlug, chapterSlug);
+        if (found.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return null;
+        }
+        BookCatalog.Chapter chapter = found.get();
+        List<Map<String, Object>> narrations = narrationsIn(chapter);
+
+        model.addAttribute("chapter", chapter);
+        model.addAttribute("narrations", narrations);
+        model.addAttribute("bookUrl", "/books/" + bookSlug);
+        model.addAttribute("seoTitle", chapter.title() + " — " + chapter.bookName());
+        model.addAttribute("seoDescription", String.format(
+                "%s: %,d narration%s from %s, in Arabic and English with full chains of transmission.",
+                chapter.title(), chapter.count(), chapter.count() == 1 ? "" : "s", chapter.bookName()));
+        model.addAttribute("canonicalUrl", BASE_URL + chapter.url());
+        model.addAttribute("jsonLd", chapterJsonLd(chapter, narrations));
+
+        LinkedHashMap<String, String> trail = new LinkedHashMap<>();
+        trail.put(chapter.bookName(), "/books/" + bookSlug);
+        trail.put(chapter.title(), chapter.url());
+        addBreadcrumbs(model, trail);
+        return "chapter";
+    }
+
+    /**
+     * The narrations of one chapter, in the book's own numbering order.
+     *
+     * <p>Filtered on the same tuple the catalog is keyed by — a chapter title alone is
+     * not unique, the same title recurs across volumes of the same book.
+     */
+    private List<Map<String, Object>> narrationsIn(BookCatalog.Chapter chapter) throws IOException {
+        List<Map<String, Object>> results = new ArrayList<>();
+        try (ESClientProvider provider = new ESClientProvider()) {
+            ElasticsearchClient client = provider.client();
+            SearchResponse<Map> response = client.search(s -> s
+                    .index(ESClientProvider.INDEX)
+                    .size(MAX_CHAPTER_NARRATIONS)
+                    .trackTotalHits(t -> t.enabled(false))
+                    .source(src -> src.filter(f -> f.includes("book", "number", "english", "arabic")))
+                    .query(q -> q.bool(b -> {
+                        b.filter(f -> f.term(t -> t.field("book").value(chapter.bookName())));
+                        b.filter(f -> f.term(t -> t.field("chapter.keyword").value(chapter.title())));
+                        addFacetFilter(b, "volume", chapter.volume());
+                        addFacetFilter(b, "part", chapter.part());
+                        addFacetFilter(b, "section", chapter.section());
+                        return b;
+                    })), Map.class);
+
+            for (Hit<Map> hit : response.hits().hits()) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> source = hit.source();
+                if (source == null) {
+                    continue;
+                }
+                Map<String, Object> row = new LinkedHashMap<>();
+                row.put("id", hit.id());
+                row.put("url", "/hadith/" + hit.id());
+                row.put("number", str(source.get("number")));
+                row.put("excerpt", excerpt(str(source.get("english"))));
+                results.add(row);
+            }
+        }
+        results.sort((a, b) -> compareNumbers(str(a.get("number")), str(b.get("number"))));
+        return results;
+    }
+
+    private static void addFacetFilter(co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery.Builder b,
+                                       String field, String value) {
+        if (value == null || value.isBlank()) {
+            // A missing facet is a real distinction: "no volume" must not match every
+            // volume, or a chapter page would list the whole book.
+            b.mustNot(m -> m.exists(e -> e.field(field)));
+            return;
+        }
+        b.filter(f -> f.term(t -> t.field(field).value(value)));
+    }
+
+    /** Sorts hadith 2 before hadith 10, falling back to text order for non-numeric labels. */
+    static int compareNumbers(String a, String b) {
+        try {
+            return Long.compare(Long.parseLong(a.trim()), Long.parseLong(b.trim()));
+        } catch (NumberFormatException e) {
+            return a.compareTo(b);
+        }
+    }
+
+    /** Volume labels are free text in the index, so they cannot go into a path raw. */
+    private static String encode(String segment) {
+        return URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private static String str(Object value) {
+        return value == null ? "" : value.toString();
+    }
+
+    private static String excerpt(String html) {
+        String text = html.replaceAll("<[^>]*>", " ").replaceAll("\\s+", " ").trim();
+        if (text.length() <= EXCERPT_CHARS) {
+            return text;
+        }
+        int cut = text.lastIndexOf(' ', EXCERPT_CHARS);
+        return text.substring(0, cut <= 0 ? EXCERPT_CHARS : cut) + "…";
+    }
+
+    /**
+     * The visible breadcrumb trail and its BreadcrumbList, built from one list so the two
+     * can never disagree — a mismatch between them is exactly what Google flags.
+     */
+    private void addBreadcrumbs(Model model, Map<String, String> trail) {
+        List<Map<String, String>> crumbs = new ArrayList<>();
+        crumbs.add(Map.of("name", "Home", "url", "/"));
+        crumbs.add(Map.of("name", "Books", "url", "/books"));
+        trail.forEach((name, url) -> crumbs.add(Map.of("name", name, "url", url)));
+        model.addAttribute("breadcrumbs", crumbs);
+        model.addAttribute("breadcrumbJsonLd", breadcrumbJsonLd(crumbs));
+    }
+
+    private String breadcrumbJsonLd(List<Map<String, String>> crumbs) {
+        List<Map<String, Object>> items = new ArrayList<>();
+        int position = 1;
+        for (Map<String, String> crumb : crumbs) {
+            items.add(new LinkedHashMap<>(Map.of(
+                    "@type", "ListItem",
+                    "position", position++,
+                    "name", crumb.get("name"),
+                    "item", BASE_URL + crumb.get("url"))));
+        }
+        Map<String, Object> ld = new LinkedHashMap<>();
+        ld.put("@context", "https://schema.org");
+        ld.put("@type", "BreadcrumbList");
+        ld.put("itemListElement", items);
+        return write(ld);
+    }
+
+    private String booksIndexJsonLd(List<BookCatalog.Book> books) {
+        List<Map<String, Object>> items = new ArrayList<>();
+        int position = 1;
+        for (BookCatalog.Book book : books) {
+            items.add(new LinkedHashMap<>(Map.of(
+                    "@type", "ListItem",
+                    "position", position++,
+                    "name", book.name(),
+                    "url", BASE_URL + "/books/" + book.slug())));
+        }
+        return write(new LinkedHashMap<>(Map.of(
+                "@context", "https://schema.org",
+                "@type", "ItemList",
+                "name", "Shia hadith collections",
+                "numberOfItems", books.size(),
+                "itemListElement", items)));
+    }
+
+    private String bookJsonLd(BookCatalog.Book book) {
+        Map<String, Object> ld = new LinkedHashMap<>();
+        ld.put("@context", "https://schema.org");
+        ld.put("@type", "Book");
+        ld.put("name", book.name());
+        ld.put("url", BASE_URL + "/books/" + book.slug());
+        ld.put("numberOfPages", book.count());
+        ld.put("inLanguage", List.of("ar", "en"));
+        ld.put("genre", "Hadith");
+        return write(ld);
+    }
+
+    private String chapterJsonLd(BookCatalog.Chapter chapter, List<Map<String, Object>> narrations) {
+        List<Map<String, Object>> items = new ArrayList<>();
+        int position = 1;
+        for (Map<String, Object> narration : narrations) {
+            items.add(new LinkedHashMap<>(Map.of(
+                    "@type", "ListItem",
+                    "position", position++,
+                    "url", BASE_URL + narration.get("url"))));
+        }
+        Map<String, Object> ld = new LinkedHashMap<>();
+        ld.put("@context", "https://schema.org");
+        ld.put("@type", "ItemList");
+        ld.put("name", chapter.title());
+        ld.put("numberOfItems", narrations.size());
+        ld.put("itemListElement", items);
+        return write(ld);
+    }
+
+    private String write(Object value) {
+        try {
+            return JSON.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        } catch (Exception e) {
+            LOGGER.warn("Could not serialise JSON-LD", e);
+            return "{}";
+        }
+    }
+}

--- a/src/main/java/com/rewayaat/controllers/HadithPageController.java
+++ b/src/main/java/com/rewayaat/controllers/HadithPageController.java
@@ -2,6 +2,9 @@ package com.rewayaat.controllers;
 
 import com.rewayaat.config.ESClientProvider;
 import com.rewayaat.core.HadithDisplaySegmenter;
+import com.rewayaat.core.HadithObjectCollection;
+import com.rewayaat.service.BookCatalog;
+import com.rewayaat.service.SimilarHadithService;
 import com.rewayaat.core.HadithSourceFilter;
 import com.rewayaat.core.data.HadithObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,8 +19,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Server-rendered hadith pages for SEO.
@@ -29,7 +35,18 @@ public class HadithPageController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HadithPageController.class);
     private static final ObjectMapper JSON = new ObjectMapper();
-    private static final String BASE_URL = "https://hadith.academyofislam.com";
+    private static final String BASE_URL = HomeController.BASE_URL;
+
+    /** Enough related reading to be useful without turning the page into a link farm. */
+    private static final int MAX_SIMILAR_LINKS = 8;
+
+    private final BookCatalog catalog;
+    private final SimilarHadithService similarHadith;
+
+    public HadithPageController(BookCatalog catalog, SimilarHadithService similarHadith) {
+        this.catalog = catalog;
+        this.similarHadith = similarHadith;
+    }
 
     @RequestMapping(value = "/{id}", method = RequestMethod.GET)
     public String hadithPage(@PathVariable("id") String id, Model model, HttpServletResponse response)
@@ -52,9 +69,11 @@ public class HadithPageController {
         String englishContent = stripHtml((String) segMap.getOrDefault("englishContent", hadith.getEnglish()));
         String englishFull = stripHtml(hadith.getEnglish());
 
-        // SEO title: "Book #Number | HDP"
+        // "HDP" is an acronym with no search volume, and it was eating the end of every
+        // title. The slot goes to words people actually search for instead.
         String bookRef = buildBookRef(hadith);
-        String seoTitle = (bookRef.isEmpty() ? truncate(englishFull, 80) : bookRef) + " | HDP - The Hadith Database";
+        String seoTitle = (bookRef.isEmpty() ? truncate(englishFull, 80) : bookRef)
+                + " — Shia Hadith in Arabic & English";
 
         // SEO description: matn text (not chain), first 160 chars
         String seoDescription = truncate(englishContent.isEmpty() ? englishFull : englishContent, 160);
@@ -65,7 +84,32 @@ public class HadithPageController {
         // JSON-LD structured data
         String jsonLd = buildJsonLd(hadith, canonicalUrl);
 
-        // Breadcrumb segments
+        // The page used to have no internal links at all beyond three copies of "/",
+        // which left all 32,519 of them as dead ends. These give a crawler somewhere to
+        // go and give the hub pages a route back down.
+        Optional<BookCatalog.Book> book = catalog.bookByName(hadith.getBook());
+        Optional<BookCatalog.Chapter> chapter = catalog.chapterFor(hadith.getBook(), hadith.getVolume(),
+                hadith.getPart(), hadith.getSection(), hadith.getChapter());
+
+        List<Map<String, String>> crumbs = new ArrayList<>();
+        crumbs.add(Map.of("name", "Home", "url", "/"));
+        crumbs.add(Map.of("name", "Books", "url", "/books"));
+        book.ifPresent(b -> {
+            crumbs.add(Map.of("name", b.name(), "url", "/books/" + b.slug()));
+            if (hadith.getVolume() != null && !hadith.getVolume().isBlank()) {
+                crumbs.add(Map.of("name", "Volume " + hadith.getVolume(),
+                        "url", "/books/" + b.slug() + "/volume/" + encode(hadith.getVolume())));
+            }
+        });
+        chapter.ifPresent(c -> crumbs.add(Map.of("name", c.title(), "url", c.url())));
+        crumbs.add(Map.of("name", "Hadith " + (hadith.getNumber() == null ? id : hadith.getNumber()),
+                "url", "/hadith/" + id));
+
+        model.addAttribute("breadcrumbs", crumbs);
+        model.addAttribute("breadcrumbJsonLd", breadcrumbJsonLd(crumbs));
+        model.addAttribute("chapterUrl", chapter.map(BookCatalog.Chapter::url).orElse(null));
+        model.addAttribute("similar", similarLinks(id));
+
         model.addAttribute("hadith", hadith);
         model.addAttribute("hadithId", id);
         model.addAttribute("seoTitle", seoTitle);
@@ -143,6 +187,59 @@ public class HadithPageController {
             LOGGER.warn("Error building JSON-LD", e);
             return "{}";
         }
+    }
+
+    /**
+     * A handful of the pre-computed LLM-judged similar narrations, as links.
+     *
+     * <p>47,522 judged-similar pairs were already sitting in the index and reachable only
+     * through an XHR the crawler never makes. Rendering a few of them server-side turns
+     * the strongest signal the corpus has about which narrations belong together into an
+     * internal link graph.
+     */
+    private List<Map<String, String>> similarLinks(String id) {
+        List<Map<String, String>> links = new ArrayList<>();
+        try {
+            HadithObjectCollection related = similarHadith.findSimilar(id, 0, MAX_SIMILAR_LINKS);
+            for (HadithObject other : related.getCollection()) {
+                String label = buildBookRef(other);
+                String excerpt = truncate(stripHtml(other.getEnglish()), 140);
+                links.add(Map.of(
+                        "url", "/hadith/" + other.getId(),
+                        "label", label.isBlank() ? "Related narration" : label,
+                        "excerpt", excerpt));
+            }
+        } catch (Exception e) {
+            // Related reading is a bonus; never fail the page over it.
+            LOGGER.warn("Could not load similar narrations for {}", id, e);
+        }
+        return links;
+    }
+
+    private String breadcrumbJsonLd(List<Map<String, String>> crumbs) {
+        List<Map<String, Object>> items = new ArrayList<>();
+        int position = 1;
+        for (Map<String, String> crumb : crumbs) {
+            items.add(new LinkedHashMap<>(Map.of(
+                    "@type", "ListItem",
+                    "position", position++,
+                    "name", crumb.get("name"),
+                    "item", BASE_URL + crumb.get("url"))));
+        }
+        Map<String, Object> ld = new LinkedHashMap<>();
+        ld.put("@context", "https://schema.org");
+        ld.put("@type", "BreadcrumbList");
+        ld.put("itemListElement", items);
+        try {
+            return JSON.writerWithDefaultPrettyPrinter().writeValueAsString(ld);
+        } catch (Exception e) {
+            LOGGER.warn("Could not build the breadcrumb JSON-LD", e);
+            return "{}";
+        }
+    }
+
+    private static String encode(String segment) {
+        return java.net.URLEncoder.encode(segment, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20");
     }
 
     private String stripHtml(String text) {

--- a/src/main/java/com/rewayaat/controllers/HadithPageController.java
+++ b/src/main/java/com/rewayaat/controllers/HadithPageController.java
@@ -203,7 +203,13 @@ public class HadithPageController {
             HadithObjectCollection related = similarHadith.findSimilar(id, 0, MAX_SIMILAR_LINKS);
             for (HadithObject other : related.getCollection()) {
                 String label = buildBookRef(other);
-                String excerpt = truncate(stripHtml(other.getEnglish()), 140);
+                // SimilarHadithService already ran the display segmenter over these, so
+                // the matn is available; excerpting the raw English would open every
+                // entry with its chain of transmission instead.
+                Object segmented = other.getAdditionalProperties().get("englishContent");
+                String body = segmented == null || segmented.toString().isBlank()
+                        ? other.getEnglish() : segmented.toString();
+                String excerpt = truncate(stripHtml(body), 140);
                 links.add(Map.of(
                         "url", "/hadith/" + other.getId(),
                         "label", label.isBlank() ? "Related narration" : label,

--- a/src/main/java/com/rewayaat/controllers/HomeController.java
+++ b/src/main/java/com/rewayaat/controllers/HomeController.java
@@ -10,6 +10,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.List;
+
+import com.rewayaat.service.BookCatalog;
+
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
@@ -21,6 +25,12 @@ import jakarta.servlet.http.HttpServletRequest;
 public class HomeController {
 
     private static final Logger log = LoggerFactory.getLogger(HomeController.class);
+
+    private final BookCatalog catalog;
+
+    public HomeController(BookCatalog catalog) {
+        this.catalog = catalog;
+    }
 
     /**
      * The host every canonical points at. The app also answers on rewayaat.info, and the
@@ -90,6 +100,13 @@ public class HomeController {
         model.addAttribute("query", query);
         model.addAttribute("page", page);
         model.addAttribute("sort_fields", sortFields);
+
+        // The home page body used to be fetched over XHR, so the served HTML carried no
+        // content and no links. It is rendered from the catalog now, which also gives the
+        // page its first internal links into the book hubs.
+        List<BookCatalog.Book> books = catalog.books();
+        model.addAttribute("books", books);
+        model.addAttribute("totalNarrations", books.stream().mapToLong(BookCatalog.Book::count).sum());
 
         model.addAttribute("seoTitle", HOME_TITLE);
         model.addAttribute("seoDescription", HOME_DESCRIPTION);

--- a/src/main/java/com/rewayaat/controllers/HomeController.java
+++ b/src/main/java/com/rewayaat/controllers/HomeController.java
@@ -22,6 +22,65 @@ public class HomeController {
 
     private static final Logger log = LoggerFactory.getLogger(HomeController.class);
 
+    /**
+     * The host every canonical points at. The app also answers on rewayaat.info, and the
+     * home page previously carried a relative {@code <link rel="canonical" href="/">},
+     * which resolves against whichever host served it — so the mirror declared itself
+     * canonical and the two domains competed for the same rankings.
+     */
+    static final String BASE_URL = "https://hadith.academyofislam.com";
+
+    /**
+     * Front-loaded with the phrase the site is trying to rank for. The old title opened
+     * with "HDP", an acronym nobody searches, and never contained the word "Shia" at all —
+     * neither did the description or the H1, so the only on-page use of the target phrase
+     * was a {@code keywords} meta, which Google has ignored since 2009.
+     */
+    static final String HOME_TITLE =
+            "Shia Hadith Database — Search 32,000+ Narrations in Arabic & English";
+
+    static final String HOME_DESCRIPTION =
+            "Search 32,000+ Shia hadith in Arabic and English. Browse Al-Kafi, Nahj al-Balagha, "
+            + "Man La Yahduruh al-Faqih and more, with similar narrations and Quranic insights.";
+
+    /**
+     * Site-level structured data. {@code WebSite} with a {@code SearchAction} is what makes a
+     * sitelinks search box eligible; {@code Organization} ties the site to the Academy for
+     * Learning Islam as a publisher. The home page previously carried no JSON-LD at all.
+     */
+    private static final String HOME_JSON_LD = """
+            [{
+              "@context": "https://schema.org",
+              "@type": "WebSite",
+              "@id": "%1$s/#website",
+              "url": "%1$s/",
+              "name": "The Hadith Database",
+              "alternateName": ["HDP", "HDP - The Hadith Database", "Shia Hadith Database"],
+              "description": "%2$s",
+              "inLanguage": ["en", "ar"],
+              "publisher": { "@id": "%1$s/#organization" },
+              "potentialAction": {
+                "@type": "SearchAction",
+                "target": {
+                  "@type": "EntryPoint",
+                  "urlTemplate": "%1$s/?q={search_term_string}"
+                },
+                "query-input": "required name=search_term_string"
+              }
+            },
+            {
+              "@context": "https://schema.org",
+              "@type": ["Organization", "EducationalOrganization"],
+              "@id": "%1$s/#organization",
+              "name": "Academy for Learning Islam",
+              "alternateName": "A.L.I.",
+              "url": "https://academyofislam.com",
+              "logo": "%1$s/img/mainlogo-transparent.png",
+              "email": "rewayaat.org@gmail.com",
+              "sameAs": ["https://github.com/rewayaat/rewayaat"]
+            }]
+            """.formatted(BASE_URL, HOME_DESCRIPTION);
+
     @RequestMapping(method = RequestMethod.GET)
     public final String home(@RequestParam(value = "q", required = false, defaultValue = "") String query,
                              @RequestParam(value = "page", defaultValue = "1") int page,
@@ -31,6 +90,17 @@ public class HomeController {
         model.addAttribute("query", query);
         model.addAttribute("page", page);
         model.addAttribute("sort_fields", sortFields);
+
+        model.addAttribute("seoTitle", HOME_TITLE);
+        model.addAttribute("seoDescription", HOME_DESCRIPTION);
+        model.addAttribute("canonicalUrl", BASE_URL + "/");
+        model.addAttribute("jsonLd", HOME_JSON_LD);
+
+        // A search result page is thin, unbounded and duplicates the narration pages it
+        // links to. The canonical already folds it into the home page; "noindex, follow"
+        // makes that explicit while still letting crawlers walk through to the results.
+        model.addAttribute("robotsDirective", query.isBlank() ? null : "noindex, follow");
+
         return "index";
     }
 

--- a/src/main/java/com/rewayaat/controllers/SitemapController.java
+++ b/src/main/java/com/rewayaat/controllers/SitemapController.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.PathVariable;
+import com.rewayaat.service.BookCatalog;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -47,6 +48,12 @@ public class SitemapController {
     private volatile List<String> cachedIds = List.of();
     private volatile Instant cachedAt = Instant.EPOCH;
 
+    private final BookCatalog catalog;
+
+    public SitemapController(BookCatalog catalog) {
+        this.catalog = catalog;
+    }
+
     @RequestMapping(value = "/sitemap.xml", method = RequestMethod.GET, produces = MediaType.APPLICATION_XML_VALUE)
     public ResponseEntity<String> sitemapIndex() {
         LOGGER.debug("Generating sitemap index");
@@ -69,6 +76,13 @@ public class SitemapController {
         xml.append("    <loc>").append(BASE_URL).append("/sitemap-static.xml</loc>\n");
         xml.append("  </sitemap>\n");
 
+        // Book, volume and chapter hubs. These are the pages that link down to the
+        // narrations, so a crawler that starts here finds the whole corpus by following
+        // links rather than by trusting the 32k-entry hadith sitemaps alone.
+        xml.append("  <sitemap>\n");
+        xml.append("    <loc>").append(BASE_URL).append("/sitemap-books.xml</loc>\n");
+        xml.append("  </sitemap>\n");
+
         // Hadith sitemap pages
         for (int i = 1; i <= totalPages; i++) {
             xml.append("  <sitemap>\n");
@@ -89,6 +103,7 @@ public class SitemapController {
         xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
 
         appendUrl(xml, "/", "1.0", "weekly");
+        appendUrl(xml, "/books", "0.9", "weekly");
         appendUrl(xml, "/updates.html", "0.6", "weekly");
         appendUrl(xml, "/search_tips.html", "0.5", "monthly");
 
@@ -96,6 +111,49 @@ public class SitemapController {
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
                 .body(xml.toString());
+    }
+
+    /**
+     * Every book, volume and chapter hub.
+     *
+     * <p>Roughly 7,800 URLs, comfortably inside the 50,000-per-file limit, so this does
+     * not page. They carry a higher priority than the narrations they lead to because
+     * they are the pages that can rank for a book or chapter name.
+     */
+    @RequestMapping(value = "/sitemap-books.xml", method = RequestMethod.GET, produces = MediaType.APPLICATION_XML_VALUE)
+    public ResponseEntity<String> booksSitemap() {
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
+
+        try {
+            appendUrl(xml, "/books", "0.9", "weekly");
+            for (BookCatalog.Book book : catalog.books()) {
+                appendUrl(xml, "/books/" + escapeXml(book.slug()), "0.9", "weekly");
+                for (String volume : book.volumes()) {
+                    appendUrl(xml, "/books/" + escapeXml(book.slug()) + "/volume/"
+                            + escapeXml(urlEncode(volume)), "0.8", "monthly");
+                }
+                for (BookCatalog.Chapter chapter : book.chapters()) {
+                    appendUrl(xml, escapeXml(chapter.url()), "0.7", "monthly");
+                }
+            }
+        } catch (Exception e) {
+            // As with the hadith pages: a 5xx tells crawlers to retry and keep the
+            // sitemap they already have, where a 200 with an empty urlset would tell
+            // them the hubs had been withdrawn.
+            LOGGER.error("Error building the books sitemap", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        xml.append("</urlset>");
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_XML)
+                .body(xml.toString());
+    }
+
+    private static String urlEncode(String segment) {
+        return java.net.URLEncoder.encode(segment, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20");
     }
 
     @RequestMapping(value = "/sitemap-hadith-{page}.xml", method = RequestMethod.GET, produces = MediaType.APPLICATION_XML_VALUE)

--- a/src/main/java/com/rewayaat/service/BookCatalog.java
+++ b/src/main/java/com/rewayaat/service/BookCatalog.java
@@ -1,0 +1,352 @@
+package com.rewayaat.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource;
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.util.NamedValue;
+import com.rewayaat.config.ESClientProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.text.Normalizer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The book / chapter structure of the corpus, addressable by URL slug.
+ *
+ * <p>Before this existed the site had no pages between the home page and the 32,519
+ * narration pages: nothing could rank for a book name, and every narration was an
+ * island reachable only from the XML sitemap, so no internal link equity reached any
+ * of them. The catalog is what {@code /books}, {@code /books/{book}} and
+ * {@code /books/{book}/{chapter}} are built from, and what puts those chapters in the
+ * sitemap.
+ *
+ * <p>Held in memory because it is small — roughly 7,700 chapters across 18 books, a
+ * couple of megabytes — and read on nearly every page render. One composite
+ * aggregation builds the whole thing; the alternative, aggregating per request, put an
+ * Elasticsearch round trip in front of every crawler hit.
+ */
+@Component
+public class BookCatalog {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BookCatalog.class);
+    private static final Duration CACHE_TTL = Duration.ofHours(6);
+    private static final int COMPOSITE_PAGE_SIZE = 1000;
+
+    /** Path segments the book routes claim, which a chapter slug must not collide with. */
+    private static final Set<String> RESERVED_SEGMENTS = Set.of("volume");
+
+    /** A book, with the chapters that sit under it in reading order. */
+    public record Book(String name, String slug, long count, List<Chapter> chapters) {
+
+        /** Volumes present in this book, in reading order, or empty when it has none. */
+        public List<String> volumes() {
+            return chapters.stream()
+                    .map(Chapter::volume)
+                    .filter(v -> v != null && !v.isBlank())
+                    .distinct()
+                    .sorted(Comparator.comparing(BookCatalog::sortKey))
+                    .toList();
+        }
+
+        public List<Chapter> chaptersInVolume(String volume) {
+            return chapters.stream()
+                    .filter(c -> volume == null ? c.volume() == null || c.volume().isBlank()
+                                                : volume.equals(c.volume()))
+                    .toList();
+        }
+    }
+
+    /**
+     * One chapter of one book.
+     *
+     * <p>{@code volume}, {@code part} and {@code section} are carried because a chapter
+     * title alone does not identify a chapter — the same title recurs across volumes —
+     * and the narration query for a chapter page has to filter on all of them.
+     */
+    public record Chapter(String bookName, String bookSlug, String slug, String title,
+                          String volume, String part, String section, long count) {
+
+        public String url() {
+            return "/books/" + bookSlug + "/" + slug;
+        }
+    }
+
+    private volatile List<Book> books = List.of();
+    private volatile Map<String, Book> booksBySlug = Map.of();
+    private volatile Map<String, Chapter> chaptersBySlug = Map.of();
+    private volatile Instant loadedAt = Instant.EPOCH;
+
+    public List<Book> books() {
+        ensureLoaded();
+        return books;
+    }
+
+    public Optional<Book> book(String slug) {
+        ensureLoaded();
+        return Optional.ofNullable(booksBySlug.get(slug));
+    }
+
+    public Optional<Chapter> chapter(String bookSlug, String chapterSlug) {
+        ensureLoaded();
+        return Optional.ofNullable(chaptersBySlug.get(bookSlug + "/" + chapterSlug));
+    }
+
+    /** Every chapter in the corpus, for the sitemap. */
+    public List<Chapter> allChapters() {
+        ensureLoaded();
+        return books.stream().flatMap(b -> b.chapters().stream()).toList();
+    }
+
+    /** The slug a narration's own book is reachable at, so a hadith page can link up. */
+    public Optional<Book> bookByName(String name) {
+        ensureLoaded();
+        if (name == null || name.isBlank()) {
+            return Optional.empty();
+        }
+        return books.stream().filter(b -> name.equals(b.name())).findFirst();
+    }
+
+    /** The chapter a narration belongs to, matched on the same tuple the catalog is keyed by. */
+    public Optional<Chapter> chapterFor(String book, String volume, String part, String section, String chapter) {
+        if (chapter == null || chapter.isBlank()) {
+            return Optional.empty();
+        }
+        return bookByName(book).flatMap(b -> b.chapters().stream()
+                .filter(c -> chapter.equals(c.title())
+                        && sameFacet(volume, c.volume())
+                        && sameFacet(part, c.part())
+                        && sameFacet(section, c.section()))
+                .findFirst());
+    }
+
+    private static boolean sameFacet(String a, String b) {
+        String left = a == null ? "" : a.trim();
+        String right = b == null ? "" : b.trim();
+        return left.equals(right);
+    }
+
+    private void ensureLoaded() {
+        if (!books.isEmpty() && Duration.between(loadedAt, Instant.now()).compareTo(CACHE_TTL) < 0) {
+            return;
+        }
+        synchronized (this) {
+            if (!books.isEmpty() && Duration.between(loadedAt, Instant.now()).compareTo(CACHE_TTL) < 0) {
+                return;
+            }
+            try {
+                load();
+            } catch (Exception e) {
+                // Serving a stale or empty catalog beats a 500 on every page. An empty
+                // catalog makes the hub pages 404, which is at least an honest answer.
+                LOGGER.error("Could not build the book catalog; keeping the previous one", e);
+            }
+        }
+    }
+
+    private void load() throws IOException {
+        long startedAt = System.currentTimeMillis();
+        List<CompositeBucket> buckets = scanChapterBuckets();
+
+        Map<String, List<Chapter>> byBook = new LinkedHashMap<>();
+        Map<String, Long> bookCounts = new LinkedHashMap<>();
+        // Slugs are unique per book, not globally: two books may both have a "Chapter on
+        // Prayer". Within a book a repeated title gets a numeric suffix, assigned in the
+        // composite aggregation's sort order so the URL stays stable across rebuilds.
+        Map<String, Integer> slugUses = new HashMap<>();
+
+        for (CompositeBucket bucket : buckets) {
+            Map<String, FieldValue> key = bucket.key();
+            String bookName = text(key.get("book"));
+            if (bookName.isBlank()) {
+                continue;
+            }
+            String bookSlug = slugify(bookName);
+            String title = text(key.get("chapter"));
+            long count = bucket.docCount();
+            bookCounts.merge(bookSlug, count, Long::sum);
+
+            if (title.isBlank()) {
+                // Narrations with no chapter still count towards the book, but there is
+                // no chapter page for them; the book page links them via its own listing.
+                continue;
+            }
+
+            String base = slugify(title);
+            if (base.isBlank()) {
+                continue;
+            }
+            if (RESERVED_SEGMENTS.contains(base)) {
+                // /books/{book}/volume/{n} is a route; a chapter that slugged to
+                // "volume" would be unreachable behind it.
+                base = base + "-chapter";
+            }
+            String slugKey = bookSlug + "/" + base;
+            int used = slugUses.merge(slugKey, 1, Integer::sum);
+            String slug = used == 1 ? base : base + "-" + used;
+
+            byBook.computeIfAbsent(bookSlug, k -> new ArrayList<>())
+                    .add(new Chapter(bookName, bookSlug, slug, title,
+                            text(key.get("volume")), text(key.get("part")), text(key.get("section")), count));
+        }
+
+        List<Book> loaded = new ArrayList<>();
+        Map<String, Book> bySlug = new LinkedHashMap<>();
+        Map<String, Chapter> chapterIndex = new LinkedHashMap<>();
+
+        for (Map.Entry<String, List<Chapter>> entry : byBook.entrySet()) {
+            String bookSlug = entry.getKey();
+            List<Chapter> chapters = List.copyOf(entry.getValue());
+            String bookName = chapters.isEmpty() ? bookSlug : chapters.get(0).bookName();
+            Book book = new Book(bookName, bookSlug, bookCounts.getOrDefault(bookSlug, 0L), chapters);
+            loaded.add(book);
+            bySlug.put(bookSlug, book);
+            for (Chapter chapter : chapters) {
+                chapterIndex.put(bookSlug + "/" + chapter.slug(), chapter);
+            }
+        }
+        loaded.sort(Comparator.comparingLong(Book::count).reversed());
+
+        this.books = List.copyOf(loaded);
+        this.booksBySlug = Map.copyOf(bySlug);
+        this.chaptersBySlug = Map.copyOf(chapterIndex);
+        this.loadedAt = Instant.now();
+
+        LOGGER.info("Book catalog built: {} books, {} chapters in {}ms",
+                books.size(), chaptersBySlug.size(), System.currentTimeMillis() - startedAt);
+    }
+
+    /**
+     * Walks every distinct (book, volume, part, section, chapter) tuple.
+     *
+     * <p>A composite aggregation is the only terms aggregation that pages, and there are
+     * far more tuples than the 10,000-bucket ceiling a plain terms aggregation allows.
+     */
+    private List<CompositeBucket> scanChapterBuckets() throws IOException {
+        List<CompositeBucket> all = new ArrayList<>();
+        try (ESClientProvider provider = new ESClientProvider()) {
+            ElasticsearchClient client = provider.client();
+            Map<String, FieldValue> after = null;
+
+            while (true) {
+                final Map<String, FieldValue> cursor = after;
+                SearchResponse<Void> response = client.search(s -> s
+                        .index(ESClientProvider.INDEX)
+                        .size(0)
+                        .trackTotalHits(t -> t.enabled(false))
+                        .aggregations("chapters", a -> a.composite(c -> {
+                            c.size(COMPOSITE_PAGE_SIZE).sources(compositeSources());
+                            if (cursor != null) {
+                                c.after(cursor);
+                            }
+                            return c;
+                        })), Void.class);
+
+                CompositeAggregate aggregate = response.aggregations().get("chapters").composite();
+                List<CompositeBucket> page = aggregate.buckets().array();
+                if (page.isEmpty()) {
+                    break;
+                }
+                all.addAll(page);
+                after = aggregate.afterKey();
+                if (after == null || after.isEmpty()) {
+                    break;
+                }
+            }
+        }
+        return all;
+    }
+
+    /**
+     * {@code chapter} is a text field with a keyword sub-field; the others are keywords
+     * already. Aggregating on the analysed field would bucket one chapter per word.
+     */
+    private static List<NamedValue<CompositeAggregationSource>> compositeSources() {
+        return List.of(
+                source("book", "book"),
+                source("volume", "volume"),
+                source("part", "part"),
+                source("section", "section"),
+                source("chapter", "chapter.keyword"));
+    }
+
+    private static NamedValue<CompositeAggregationSource> source(String name, String field) {
+        return NamedValue.of(name, CompositeAggregationSource.of(s -> s
+                .terms(t -> t.field(field).missingBucket(true))));
+    }
+
+    private static String text(FieldValue value) {
+        if (value == null || value.isNull()) {
+            return "";
+        }
+        return value.stringValue() == null ? "" : value.stringValue().trim();
+    }
+
+    /**
+     * A URL-safe slug.
+     *
+     * <p>Book and chapter titles are transliterated Arabic full of combining marks and
+     * dots below — "Man Lā Yaḥḍuruh al-Faqīh", "ʿUyūn akhbār al-Riḍā". Stripping the
+     * diacritics before slugifying gives the plain-ASCII spelling people actually type
+     * and link to, so the URL matches the query.
+     */
+    public static String slugify(String input) {
+        if (input == null) {
+            return "";
+        }
+        String decomposed = Normalizer.normalize(input, Normalizer.Form.NFD);
+        StringBuilder ascii = new StringBuilder(decomposed.length());
+        for (int i = 0; i < decomposed.length(); i++) {
+            char c = decomposed.charAt(i);
+            int type = Character.getType(c);
+            if (type == Character.NON_SPACING_MARK || type == Character.COMBINING_SPACING_MARK) {
+                continue;
+            }
+            ascii.append(c);
+        }
+        String slug = ascii.toString()
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("^-+|-+$", "");
+        // Chapter titles run long; a slug past this adds nothing a crawler or a reader uses.
+        return slug.length() > 80 ? slug.substring(0, slug.lastIndexOf('-', 80) < 20 ? 80 : slug.lastIndexOf('-', 80)) : slug;
+    }
+
+    /** Sorts "Volume 10" after "Volume 9" rather than between 1 and 2. */
+    private static String sortKey(String value) {
+        StringBuilder out = new StringBuilder();
+        for (String token : value.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)")) {
+            if (!token.isEmpty() && Character.isDigit(token.charAt(0))) {
+                out.append(String.format("%08d", Long.parseLong(token.replaceAll("\\D", "0"))));
+            } else {
+                out.append(token);
+            }
+        }
+        return out.toString();
+    }
+
+    /** Builds the catalog off the request path, the way the sitemap cache is warmed. */
+    @EventListener(ApplicationReadyEvent.class)
+    public void warmOnStartup() {
+        Thread warmer = new Thread(this::ensureLoaded, "book-catalog-warmer");
+        warmer.setDaemon(true);
+        warmer.start();
+    }
+}

--- a/src/main/resources/static/css/manuscript.css
+++ b/src/main/resources/static/css/manuscript.css
@@ -10106,3 +10106,84 @@ body.is-search-mode .site-nav .search-entry-shell {
         z-index: 2;
     }
 }
+
+/* ---------------------------------------------------------------------------
+   Home page prose and the book index.
+
+   Both are rendered by the server. The home page body used to be fetched over
+   XHR, so it carried no readable copy and no links; these are the styles for the
+   copy and the links that replaced that.
+   --------------------------------------------------------------------------- */
+
+/* Sits on the dark hero card, so it takes the hero's palette rather than the
+   page's body colours the way the rest of the home page prose does. */
+.home-hero__lede {
+    font-family: 'Source Serif 4', Georgia, serif;
+    font-size: 1rem;
+    line-height: 1.7;
+    color: rgba(245, 236, 214, 0.82);
+    width: min(100%, 760px);
+    margin: 0 auto 0.9rem;
+    text-align: center;
+}
+
+.home-hero__lede strong {
+    color: #f6df88;
+    font-weight: 600;
+}
+
+.home-hero__lede a {
+    color: rgba(245, 236, 214, 0.95);
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
+.home-hero__lede a:hover {
+    color: #f6df88;
+}
+
+.home-books__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    gap: 0.75rem;
+}
+
+.home-books__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--bs-border-color, #e3e0d8);
+    border-radius: 0.55rem;
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.home-books__item:hover {
+    border-color: var(--bs-secondary-color, #8a8578);
+    background: var(--bs-tertiary-bg, #faf8f3);
+}
+
+.home-books__name {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-weight: 600;
+    font-size: 1.12rem;
+    line-height: 1.25;
+}
+
+.home-books__count {
+    font-size: 0.8rem;
+    color: var(--bs-secondary-color, #7a756a);
+}
+
+@media (max-width: 575.98px) {
+    .home-hero__lede {
+        font-size: 0.95rem;
+        text-align: left;
+    }
+
+    .home-books__grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}

--- a/src/main/resources/static/js/rewayaat.js
+++ b/src/main/resources/static/js/rewayaat.js
@@ -1280,8 +1280,10 @@ function ensurePublicHomeVisible() {
     if (!welcome) {
         return;
     }
-    var hasWelcome = welcome.innerHTML && welcome.innerHTML.trim().length > 0;
-    if (hasWelcome || welcomeContentInitialized) {
+    // Previously this bailed whenever the section had any markup in it. Now the server
+    // renders that markup, so "has content" no longer means "has been bound" — only the
+    // initialised flag does.
+    if (welcomeContentInitialized) {
         return;
     }
     displayWelcomeContent();
@@ -2594,6 +2596,26 @@ function showBookBlurb(bookName) {
     }
 }
 
+/**
+ * The home page body as the server rendered it.
+ *
+ * The body used to be fetched from /welcome.html over XHR, which meant the served page
+ * carried no content and no links for any crawler that does not run scripts. It is now
+ * part of the document, and this holds a copy so that returning from a search can put
+ * it back without a round trip.
+ */
+var welcomeInitialMarkup = null;
+
+function captureWelcomeMarkup() {
+    if (welcomeInitialMarkup !== null) {
+        return;
+    }
+    var welcome = document.getElementById('welcome');
+    if (welcome && welcome.innerHTML.trim().length > 0) {
+        welcomeInitialMarkup = welcome.innerHTML;
+    }
+}
+
 function displayWelcomeContent() {
     if (isCollectionMode()) {
         return;
@@ -2601,6 +2623,7 @@ function displayWelcomeContent() {
     if (welcomeContentLoading) {
         return;
     }
+    captureWelcomeMarkup();
     welcomeContentLoading = true;
     var queryBar = document.getElementById('queryBar');
     if (queryBar) {
@@ -2612,44 +2635,56 @@ function displayWelcomeContent() {
     vueApp = new Vue({
         el: '#hadithView'
     });
-    $("#welcome").load("/welcome.html?v=33", function(responseData, statusText) {
-        welcomeContentLoading = false;
-        welcomeContentInitialized = statusText === 'success';
-        var queryBar = document.getElementById('queryBar');
-        var heroSlot = document.getElementById('hero-search-slot');
-        if (queryBar) {
-            if (heroSlot) {
-                heroSlot.appendChild(queryBar);
-                queryBar.classList.add('home-search');
-            } else {
-                queryBar.classList.remove('home-search');
-            }
-            queryBar.classList.remove('is-hidden');
-            queryBar.classList.add('is-visible');
+
+    var welcome = document.getElementById('welcome');
+    if (welcome && welcome.innerHTML.trim().length === 0 && welcomeInitialMarkup !== null) {
+        // Coming back from a search, which empties the section.
+        welcome.innerHTML = welcomeInitialMarkup;
+    }
+    welcomeContentLoading = false;
+    welcomeContentInitialized = !!(welcome && welcome.innerHTML.trim().length > 0);
+    initWelcomeContent();
+}
+
+/**
+ * Binds the home page body. Runs whether the markup came from the server on first paint
+ * or was restored after a search, so the two paths cannot drift apart.
+ */
+function initWelcomeContent() {
+    var queryBar = document.getElementById('queryBar');
+    var heroSlot = document.getElementById('hero-search-slot');
+    if (queryBar) {
+        if (heroSlot) {
+            heroSlot.appendChild(queryBar);
+            queryBar.classList.add('home-search');
+        } else {
+            queryBar.classList.remove('home-search');
         }
-        if (statusText !== 'success') {
-            return;
-        }
-        // initialize search bar
-        initSelect2('searchTerms');
-        // setup select handler
-        select2SelectHandler('searchTerms');
-        // setup enter key listener
-        setupSelect2EnterKeyListener('searchTerms');
-        // auto-focus search input on home page
-        if (searchSelectControl && searchSelectControl.control_input) {
-            searchSelectControl.control_input.focus();
-        }
-        // refresh auth bindings for dynamically loaded welcome content
-        initAuthUI();
-        if (authState.authenticated) {
-            loadAndRenderCollections(false);
-        }
-        // load recent updates
-        loadRecentUpdates();
-        // load browse data
-        loadBrowseBooks();
-    });
+        queryBar.classList.remove('is-hidden');
+        queryBar.classList.add('is-visible');
+    }
+    if (!welcomeContentInitialized) {
+        return;
+    }
+    // initialize search bar
+    initSelect2('searchTerms');
+    // setup select handler
+    select2SelectHandler('searchTerms');
+    // setup enter key listener
+    setupSelect2EnterKeyListener('searchTerms');
+    // auto-focus search input on home page
+    if (searchSelectControl && searchSelectControl.control_input) {
+        searchSelectControl.control_input.focus();
+    }
+    // refresh auth bindings for dynamically loaded welcome content
+    initAuthUI();
+    if (authState.authenticated) {
+        loadAndRenderCollections(false);
+    }
+    // load recent updates
+    loadRecentUpdates();
+    // load browse data
+    loadBrowseBooks();
 }
 
 function indicatePendingSearchTerms() {
@@ -4474,7 +4509,8 @@ function validQuery(query) {
  * created Vue instance in the global vueApp variable.
  */
 function setupVue(query, page, sortFields) {
-    // clear welcome page content
+    // clear welcome page content, keeping a copy so returning home needs no round trip
+    captureWelcomeMarkup();
     document.getElementById('welcome').innerHTML = '';
     // Setup hadith vue component
     vueApp = new Vue({

--- a/src/main/resources/templates/book.html
+++ b/src/main/resources/templates/book.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/site :: head}"></head>
+<head th:replace="~{fragments/site :: sitehead}"></head>
 <body>
-<nav th:replace="~{fragments/site :: nav}"></nav>
+<nav th:replace="~{fragments/site :: sitenav}"></nav>
 
 <main class="container py-3">
-    <nav th:replace="~{fragments/site :: crumbs}"></nav>
+    <nav th:replace="~{fragments/site :: crumbtrail}"></nav>
 
     <header class="hub-hero">
         <h1 class="hub-hero__title" th:text="${book.name}">Book name</h1>
@@ -44,7 +44,7 @@
     </section>
 </main>
 
-<footer th:replace="~{fragments/site :: footer}"></footer>
+<footer th:replace="~{fragments/site :: sitefooter}"></footer>
 <th:block th:replace="~{fragments/site :: analytics}"></th:block>
 </body>
 </html>

--- a/src/main/resources/templates/book.html
+++ b/src/main/resources/templates/book.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/site :: head}"></head>
+<body>
+<nav th:replace="~{fragments/site :: nav}"></nav>
+
+<main class="container py-3">
+    <nav th:replace="~{fragments/site :: crumbs}"></nav>
+
+    <header class="hub-hero">
+        <h1 class="hub-hero__title" th:text="${book.name}">Book name</h1>
+        <p class="hub-hero__lede">
+            <strong th:text="${#numbers.formatInteger(book.count, 0, 'COMMA')}">1,000</strong> narrations
+            across <span th:text="${#numbers.formatInteger(#lists.size(book.chapters), 0, 'COMMA')}">100</span>
+            chapters, in Arabic and English.
+        </p>
+    </header>
+
+    <!-- The shipped description of the collection, where one exists for this book. -->
+    <div class="hub-blurb" th:if="${blurb != null}" th:utext="${blurb}"></div>
+
+    <!-- Books with volumes list those; the chapters live one level down so that no
+         single page carries thousands of links. Flat books list chapters directly. -->
+    <section th:if="${!#lists.isEmpty(volumes)}">
+        <h2 class="hub-group__label">Volumes</h2>
+        <div class="hub-grid">
+            <a class="hub-card" th:each="volume : ${volumes}" th:href="${volume.url}">
+                <div class="hub-card__title" th:text="${volume.label}">Volume 1</div>
+                <div class="hub-card__meta">
+                    <span th:text="${#numbers.formatInteger(volume.chapterCount, 0, 'COMMA')}">100</span> chapters
+                </div>
+            </a>
+        </div>
+    </section>
+
+    <section th:if="${!#lists.isEmpty(chapters)}">
+        <h2 class="hub-group__label">Chapters</h2>
+        <ul class="hub-list">
+            <li th:each="chapter : ${chapters}">
+                <a th:href="${chapter.url}" th:text="${chapter.title}">Chapter title</a>
+                <span class="hub-list__count" th:text="'(' + ${chapter.count} + ')'">(12)</span>
+            </li>
+        </ul>
+    </section>
+</main>
+
+<footer th:replace="~{fragments/site :: footer}"></footer>
+<th:block th:replace="~{fragments/site :: analytics}"></th:block>
+</body>
+</html>

--- a/src/main/resources/templates/books.html
+++ b/src/main/resources/templates/books.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/site :: head}"></head>
+<head th:replace="~{fragments/site :: sitehead}"></head>
 <body>
-<nav th:replace="~{fragments/site :: nav}"></nav>
+<nav th:replace="~{fragments/site :: sitenav}"></nav>
 
 <main class="container py-3">
-    <nav th:replace="~{fragments/site :: crumbs}"></nav>
+    <nav th:replace="~{fragments/site :: crumbtrail}"></nav>
 
     <header class="hub-hero">
         <h1 class="hub-hero__title">Shia Hadith Books</h1>
@@ -30,7 +30,7 @@
     </div>
 </main>
 
-<footer th:replace="~{fragments/site :: footer}"></footer>
+<footer th:replace="~{fragments/site :: sitefooter}"></footer>
 <th:block th:replace="~{fragments/site :: analytics}"></th:block>
 </body>
 </html>

--- a/src/main/resources/templates/books.html
+++ b/src/main/resources/templates/books.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/site :: head}"></head>
+<body>
+<nav th:replace="~{fragments/site :: nav}"></nav>
+
+<main class="container py-3">
+    <nav th:replace="~{fragments/site :: crumbs}"></nav>
+
+    <header class="hub-hero">
+        <h1 class="hub-hero__title">Shia Hadith Books</h1>
+        <p class="hub-hero__lede">
+            The primary Shi'i hadith collections, in Arabic with English translation —
+            <strong th:text="${#numbers.formatInteger(totalNarrations, 0, 'COMMA')}">32,000</strong>
+            narrations across <span th:text="${#lists.size(books)}">18</span> books. Every narration
+            carries its chain of transmission, and is cross-linked to similar narrations and to the
+            Qur'anic verses it draws on.
+        </p>
+    </header>
+
+    <div class="hub-grid">
+        <a class="hub-card" th:each="book : ${books}" th:href="@{'/books/' + ${book.slug}}">
+            <div class="hub-card__title" th:text="${book.name}">Book name</div>
+            <div class="hub-card__meta">
+                <span th:text="${#numbers.formatInteger(book.count, 0, 'COMMA')}">1,000</span> narrations
+                &middot;
+                <span th:text="${#numbers.formatInteger(#lists.size(book.chapters), 0, 'COMMA')}">100</span> chapters
+            </div>
+        </a>
+    </div>
+</main>
+
+<footer th:replace="~{fragments/site :: footer}"></footer>
+<th:block th:replace="~{fragments/site :: analytics}"></th:block>
+</body>
+</html>

--- a/src/main/resources/templates/chapter.html
+++ b/src/main/resources/templates/chapter.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/site :: head}"></head>
+<head th:replace="~{fragments/site :: sitehead}"></head>
 <body>
-<nav th:replace="~{fragments/site :: nav}"></nav>
+<nav th:replace="~{fragments/site :: sitenav}"></nav>
 
 <main class="container py-3">
-    <nav th:replace="~{fragments/site :: crumbs}"></nav>
+    <nav th:replace="~{fragments/site :: crumbtrail}"></nav>
 
     <header class="hub-hero">
         <h1 class="hub-hero__title" th:text="${chapter.title}">Chapter title</h1>
@@ -32,7 +32,7 @@
     </div>
 </main>
 
-<footer th:replace="~{fragments/site :: footer}"></footer>
+<footer th:replace="~{fragments/site :: sitefooter}"></footer>
 <th:block th:replace="~{fragments/site :: analytics}"></th:block>
 </body>
 </html>

--- a/src/main/resources/templates/chapter.html
+++ b/src/main/resources/templates/chapter.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/site :: head}"></head>
+<body>
+<nav th:replace="~{fragments/site :: nav}"></nav>
+
+<main class="container py-3">
+    <nav th:replace="~{fragments/site :: crumbs}"></nav>
+
+    <header class="hub-hero">
+        <h1 class="hub-hero__title" th:text="${chapter.title}">Chapter title</h1>
+        <p class="hub-hero__lede">
+            <a th:href="${bookUrl}" th:text="${chapter.bookName}">Book</a>
+            <th:block th:if="${!#strings.isEmpty(chapter.volume)}">
+                &middot; Volume <span th:text="${chapter.volume}">1</span>
+            </th:block>
+            <th:block th:if="${!#strings.isEmpty(chapter.section)}">
+                &middot; Section <span th:text="${chapter.section}">1</span>
+            </th:block>
+            &middot; <span th:text="${#numbers.formatInteger(chapter.count, 0, 'COMMA')}">12</span> narrations
+        </p>
+    </header>
+
+    <div>
+        <article class="hub-narration" th:each="narration : ${narrations}">
+            <div class="hub-narration__num" th:if="${!#strings.isEmpty(narration.number)}">
+                Hadith <span th:text="${narration.number}">1</span>
+            </div>
+            <p class="hub-narration__text" th:text="${narration.excerpt}">Excerpt of the narration.</p>
+            <a class="hub-narration__link" th:href="${narration.url}">Read the full narration &rarr;</a>
+        </article>
+    </div>
+</main>
+
+<footer th:replace="~{fragments/site :: footer}"></footer>
+<th:block th:replace="~{fragments/site :: analytics}"></th:block>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/home-content.html
+++ b/src/main/resources/templates/fragments/home-content.html
@@ -1,3 +1,13 @@
+<!--
+  The home page body.
+
+  This lived in static/welcome.html and was injected with $("#welcome").load(...),
+  which meant the raw home page was ~400 words of Vue template chrome: the hero, the
+  book list and the disclaimer were invisible to any crawler that does not execute
+  scripts, and the page had no internal links at all. It is now rendered by the server
+  and the script reuses the markup that is already in the document.
+-->
+<div th:fragment="body" xmlns:th="http://www.thymeleaf.org">
 <section class="home-hero">
     <div class="home-hero__card">
         <div class="home-hero__layout">
@@ -6,6 +16,17 @@
                 <div class="home-hero__brand">
                     <img src="/img/mainlogo-transparent.png" class="home-hero__logo" alt="The Hadith Database logo" />
                 </div>
+                <!-- Real prose on the home page, which previously carried none a crawler
+                     could read. It is also the only place the phrase the site is trying
+                     to rank for appears in the visible copy. -->
+                <p class="home-hero__lede">
+                    A searchable database of <strong>Shia hadith</strong> &mdash;
+                    <strong th:text="${#numbers.formatInteger(totalNarrations, 0, 'COMMA')}">32,000</strong>
+                    narrations of the Prophet and the Ahlul Bayt, in the original Arabic with English
+                    translation, drawn from <a href="/books">Al-Kafi, Nahj al-Balagha, Man La Yahduruh
+                    al-Faqih and other primary collections</a>. Every narration keeps its chain of
+                    transmission and links to similar narrations and the Qur'anic verses it draws on.
+                </p>
                 <p class="home-hero__search-note">
                     Search in <span>English</span> or <span>Arabic</span> by single terms or phrases wrapped in quotations.
                 </p>
@@ -148,6 +169,30 @@
     <div id="collectionsEmpty" class="small text-muted">No collections yet. Save a hadith to create your first list.</div>
 </section>
 
+
+<section class="home-books" id="collections">
+    <div class="home-section-header">
+        <div>
+            <h2 class="home-section-title">The Collections</h2>
+            <p class="home-section-subtitle">
+                Every book in the database, with its chapters laid out for reading.
+                <a href="/books" class="recent-updates-more">See all books &#8594;</a>
+            </p>
+        </div>
+    </div>
+    <!-- Server-rendered on purpose. The rest of this page is fetched over XHR, so a
+         crawler that does not run scripts saw a page with no content and no links;
+         these are the links that lead down into the 32,000 narrations. -->
+    <div class="home-books__grid">
+        <a class="home-books__item" th:each="book : ${books}" th:href="@{'/books/' + ${book.slug}}">
+            <span class="home-books__name" th:text="${book.name}">Al-Kafi</span>
+            <span class="home-books__count">
+                <span th:text="${#numbers.formatInteger(book.count, 0, 'COMMA')}">14,242</span> narrations
+            </span>
+        </a>
+    </div>
+</section>
+
 <section class="home-notice" id="about">
     <div class="card shadow-sm border-0 home-card">
         <div class="card-body">
@@ -161,3 +206,5 @@
         </div>
     </div>
 </section>
+
+</div>

--- a/src/main/resources/templates/fragments/site.html
+++ b/src/main/resources/templates/fragments/site.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+<!--
+  Shared chrome for the server-rendered pages (books, book, chapter).
+
+  These pages exist to be crawled, so everything on them is real HTML rendered by the
+  server: the rest of the site builds its content in the browser, and a crawler that
+  does not run scripts sees an empty shell.
+-->
+<head th:fragment="head">
+    <meta charset="UTF-8"/>
+    <title th:text="${seoTitle}">The Hadith Database</title>
+    <meta name="description" th:content="${seoDescription}"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="canonical" th:href="${canonicalUrl}"/>
+
+    <meta property="og:type" content="website"/>
+    <meta property="og:site_name" content="The Hadith Database"/>
+    <meta property="og:title" th:content="${seoTitle}"/>
+    <meta property="og:description" th:content="${seoDescription}"/>
+    <meta property="og:url" th:content="${canonicalUrl}"/>
+    <meta property="og:image" content="https://hadith.academyofislam.com/img/share-card.png"/>
+    <meta property="og:image:width" content="1200"/>
+    <meta property="og:image:height" content="630"/>
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:title" th:content="${seoTitle}"/>
+    <meta name="twitter:description" th:content="${seoDescription}"/>
+    <meta name="twitter:image" content="https://hadith.academyofislam.com/img/share-card.png"/>
+
+    <script type="application/ld+json" th:utext="${jsonLd}"></script>
+    <script type="application/ld+json" th:utext="${breadcrumbJsonLd}" th:if="${breadcrumbJsonLd != null}"></script>
+
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin/>
+    <link rel="preconnect" href="https://fonts.googleapis.com"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="/css/manuscript.css" rel="stylesheet" th:href="@{/css/manuscript.css}"/>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&family=Scheherazade+New:wght@400;700&display=swap"
+          rel="stylesheet"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+          integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <style>
+        .hub-hero { padding: 2rem 0 1.25rem; border-bottom: 1px solid var(--bs-border-color); margin-bottom: 1.75rem; }
+        .hub-hero__title { font-family: 'Cormorant Garamond', serif; font-weight: 700; font-size: 2rem; line-height: 1.15; margin-bottom: 0.4rem; }
+        .hub-hero__lede { font-family: 'Source Serif 4', serif; font-size: 1.05rem; line-height: 1.7; color: var(--bs-secondary-color); max-width: 62ch; }
+        .hub-crumbs { display: flex; flex-wrap: wrap; gap: 0.35rem; font-size: 0.85rem; color: var(--bs-secondary-color); margin-bottom: 0.85rem; }
+        .hub-crumbs a { color: var(--bs-secondary-color); text-decoration: none; }
+        .hub-crumbs a:hover { color: var(--bs-body-color); text-decoration: underline; }
+        .hub-crumbs__sep { opacity: 0.4; }
+        .hub-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; }
+        .hub-card { display: block; padding: 1rem 1.15rem; border: 1px solid var(--bs-border-color); border-radius: 0.6rem; text-decoration: none; color: inherit; transition: border-color 0.15s, background 0.15s; }
+        .hub-card:hover { border-color: var(--bs-secondary-color); background: var(--bs-tertiary-bg); }
+        .hub-card__title { font-family: 'Cormorant Garamond', serif; font-weight: 600; font-size: 1.2rem; line-height: 1.25; margin-bottom: 0.2rem; }
+        .hub-card__meta { font-size: 0.82rem; color: var(--bs-secondary-color); }
+        .hub-group { margin-bottom: 2rem; }
+        .hub-group__label { font-family: 'Source Serif 4', serif; font-weight: 600; font-size: 1rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--bs-secondary-color); margin-bottom: 0.75rem; padding-bottom: 0.4rem; border-bottom: 1px solid var(--bs-border-color); }
+        .hub-list { list-style: none; padding: 0; margin: 0; column-width: 20rem; column-gap: 2rem; }
+        .hub-list li { break-inside: avoid; margin-bottom: 0.45rem; font-size: 0.95rem; line-height: 1.45; }
+        .hub-list a { text-decoration: none; color: var(--bs-body-color); }
+        .hub-list a:hover { text-decoration: underline; }
+        .hub-list__count { color: var(--bs-secondary-color); font-size: 0.8rem; }
+        .hub-blurb { font-family: 'Source Serif 4', serif; line-height: 1.7; margin-bottom: 2rem; }
+        .hub-blurb h2 { font-family: 'Cormorant Garamond', serif; font-size: 1.4rem; }
+        .hub-narration { padding: 1rem 0; border-bottom: 1px solid var(--bs-border-color); }
+        .hub-narration__num { font-size: 0.8rem; color: var(--bs-secondary-color); letter-spacing: 0.04em; }
+        .hub-narration__text { font-family: 'Source Serif 4', serif; font-size: 1rem; line-height: 1.65; margin: 0.25rem 0 0.4rem; }
+        .hub-narration__link { font-size: 0.85rem; text-decoration: none; }
+    </style>
+</head>
+
+<body>
+<nav th:fragment="nav" class="navbar navbar-expand-lg sticky-top site-nav">
+    <div class="container">
+        <div class="navbar-top w-100 d-flex align-items-center flex-wrap gap-3">
+            <a class="navbar-brand d-flex align-items-center gap-2" href="/">
+                <img src="/img/Alilogov2-transparent.png" th:src="@{/img/Alilogov2-transparent.png}" class="brand-logo--full brand-logo--full-v2 d-none d-md-block" alt="ALI Logo"/>
+                <img src="/img/ali_icon.png" th:src="@{/img/ali_icon.png}" class="brand-logo--icon d-md-none" alt="ALI"/>
+            </a>
+            <div class="d-flex home-nav-links">
+                <a href="/" class="home-nav-link">Search</a>
+                <span class="home-nav-dot" aria-hidden="true">&middot;</span>
+                <a href="/books" class="home-nav-link">Books</a>
+                <span class="home-nav-dot" aria-hidden="true">&middot;</span>
+                <a href="/updates.html" class="home-nav-link">Updates</a>
+            </div>
+        </div>
+    </div>
+</nav>
+
+<!-- The visible trail, rendered from the same list the BreadcrumbList is built from. -->
+<nav th:fragment="crumbs" class="hub-crumbs" aria-label="Breadcrumb">
+    <th:block th:each="crumb, it : ${breadcrumbs}">
+        <span th:if="${!it.first}" class="hub-crumbs__sep">/</span>
+        <a th:if="${!it.last}" th:href="${crumb.url}" th:text="${crumb.name}">Crumb</a>
+        <span th:if="${it.last}" th:text="${crumb.name}">Current</span>
+    </th:block>
+</nav>
+
+<footer th:fragment="footer" class="site-footer">
+    <div class="container">
+        <div class="site-footer__grid">
+            <div>
+                <div class="site-footer__title">Rewayaat</div>
+                <p class="site-footer__text">
+                    A project of the <a href="https://academyofislam.com" target="_blank" rel="noopener noreferrer" class="site-footer__link">Academy for Learning Islam</a>. Search, browse, and study Shi'i narrations in Arabic and English.
+                </p>
+            </div>
+            <div>
+                <div class="site-footer__label">Explore</div>
+                <div class="site-footer__links">
+                    <a href="/books">All Books</a>
+                    <a href="/updates.html">Updates</a>
+                    <a href="/search_tips.html">Search Tips</a>
+                </div>
+            </div>
+            <div>
+                <div class="site-footer__label">Contact</div>
+                <div class="site-footer__links">
+                    <a href="mailto:rewayaat.org@gmail.com">rewayaat.org@gmail.com</a>
+                    <a href="https://github.com/rewayaat/rewayaat" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+                    <a href="https://academyofislam.com" target="_blank" rel="noopener noreferrer">Academy of Islam</a>
+                </div>
+            </div>
+        </div>
+        <div class="site-footer__bottom">
+            <span>&copy; 2026 Academy for Learning Islam (A.L.I.)</span>
+            <span>Content and translations remain the responsibility of their original sources.</span>
+        </div>
+    </div>
+</footer>
+
+<th:block th:fragment="analytics">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-3HSRTQD7GM"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-3HSRTQD7GM');
+    </script>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/site.html
+++ b/src/main/resources/templates/fragments/site.html
@@ -3,11 +3,16 @@
 <!--
   Shared chrome for the server-rendered pages (books, book, chapter).
 
+  Fragment names deliberately avoid being HTML tag names. Thymeleaf's "::name" resolves
+  a fragment name first but also matches it as a tag selector, so a fragment called
+  "nav" pulled in every <nav> in this file — the site header and the breadcrumb trail
+  both — and every page rendered its breadcrumbs twice.
+
   These pages exist to be crawled, so everything on them is real HTML rendered by the
   server: the rest of the site builds its content in the browser, and a crawler that
   does not run scripts sees an empty shell.
 -->
-<head th:fragment="head">
+<head th:fragment="sitehead">
     <meta charset="UTF-8"/>
     <title th:text="${seoTitle}">The Hadith Database</title>
     <meta name="description" th:content="${seoDescription}"/>
@@ -70,7 +75,7 @@
 </head>
 
 <body>
-<nav th:fragment="nav" class="navbar navbar-expand-lg sticky-top site-nav">
+<nav th:fragment="sitenav" class="navbar navbar-expand-lg sticky-top site-nav">
     <div class="container">
         <div class="navbar-top w-100 d-flex align-items-center flex-wrap gap-3">
             <a class="navbar-brand d-flex align-items-center gap-2" href="/">
@@ -89,7 +94,7 @@
 </nav>
 
 <!-- The visible trail, rendered from the same list the BreadcrumbList is built from. -->
-<nav th:fragment="crumbs" class="hub-crumbs" aria-label="Breadcrumb">
+<nav th:fragment="crumbtrail" class="hub-crumbs" aria-label="Breadcrumb">
     <th:block th:each="crumb, it : ${breadcrumbs}">
         <span th:if="${!it.first}" class="hub-crumbs__sep">/</span>
         <a th:if="${!it.last}" th:href="${crumb.url}" th:text="${crumb.name}">Crumb</a>
@@ -97,7 +102,7 @@
     </th:block>
 </nav>
 
-<footer th:fragment="footer" class="site-footer">
+<footer th:fragment="sitefooter" class="site-footer">
     <div class="container">
         <div class="site-footer__grid">
             <div>

--- a/src/main/resources/templates/hadith.html
+++ b/src/main/resources/templates/hadith.html
@@ -26,6 +26,7 @@
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json" th:utext="${jsonLd}"></script>
+    <script type="application/ld+json" th:utext="${breadcrumbJsonLd}" th:if="${breadcrumbJsonLd != null}"></script>
 
     <!-- Styles -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin/>
@@ -65,6 +66,14 @@
         .hp-share__btn:hover { color: var(--bs-body-color); border-color: var(--bs-secondary-color); background: var(--bs-tertiary-bg); }
         .hp-share__toast { display: inline-block; margin-left: 0.75rem; font-size: 0.8rem; color: #198754; opacity: 0; transition: opacity 0.3s; }
         .hp-share__toast.show { opacity: 1; }
+        .hp-related { margin-top: 2.5rem; padding-top: 1.25rem; border-top: 1px solid var(--bs-border-color); }
+        .hp-related__title { font-family: 'Cormorant Garamond', serif; font-weight: 700; font-size: 1.3rem; margin-bottom: 0.85rem; }
+        .hp-related__list { list-style: none; padding: 0; margin: 0; }
+        .hp-related__list li { padding: 0.6rem 0; border-bottom: 1px solid var(--bs-border-color); }
+        .hp-related__list a { font-family: 'Source Serif 4', serif; font-weight: 600; text-decoration: none; }
+        .hp-related__list a:hover { text-decoration: underline; }
+        .hp-related__excerpt { display: block; font-size: 0.88rem; line-height: 1.5; color: var(--bs-secondary-color); margin-top: 0.15rem; }
+        .hp-onward { display: flex; flex-wrap: wrap; gap: 1.5rem; }
     </style>
 </head>
 
@@ -80,7 +89,7 @@
             <div class="d-flex home-nav-links">
                 <a href="/" class="home-nav-link">Search</a>
                 <span class="home-nav-dot" aria-hidden="true">&middot;</span>
-                <a href="/#browse" class="home-nav-link">Browse</a>
+                <a href="/books" class="home-nav-link">Books</a>
                 <span class="home-nav-dot" aria-hidden="true">&middot;</span>
                 <a href="/updates.html" class="home-nav-link">Updates</a>
             </div>
@@ -99,23 +108,16 @@
                 Hadith <span th:text="${hadith.number}">123</span>
             </span>
 
-            <!-- Breadcrumb path: Part > Section > Chapter -->
-            <div class="hp-hero__path" th:if="${hadith.part != null and !hadith.part.isBlank()}">
-                <span th:if="${hadith.volume != null and !hadith.volume.isBlank()}"
-                      class="hp-hero__path-segment">Volume <span th:text="${hadith.volume}">1</span></span>
-                <span th:if="${hadith.volume != null and !hadith.volume.isBlank()}"
-                      class="hp-hero__path-sep">/</span>
-                <span th:if="${hadith.part != null and !hadith.part.isBlank()}"
-                      class="hp-hero__path-current" th:text="${hadith.part}">Part Name</span>
-                <span th:if="${hadith.section != null and !hadith.section.isBlank()}"
-                      class="hp-hero__path-sep">/</span>
-                <span th:if="${hadith.section != null and !hadith.section.isBlank()}"
-                      class="hp-hero__path-current" th:text="${hadith.section}">Section</span>
-                <span th:if="${hadith.chapter != null and !hadith.chapter.isBlank()}"
-                      class="hp-hero__path-sep">/</span>
-                <span th:if="${hadith.chapter != null and !hadith.chapter.isBlank()}"
-                      class="hp-hero__path-current" th:text="${hadith.chapter}">Chapter</span>
-            </div>
+            <!-- Breadcrumb path. These were <span>s: the page named its book, volume and
+                 chapter but linked to none of them, so every narration was a dead end. -->
+            <nav class="hp-hero__path" aria-label="Breadcrumb">
+                <th:block th:each="crumb, it : ${breadcrumbs}">
+                    <span th:if="${!it.first}" class="hp-hero__path-sep">/</span>
+                    <a th:if="${!it.last}" class="hp-hero__path-link"
+                       th:href="${crumb.url}" th:text="${crumb.name}">Crumb</a>
+                    <span th:if="${it.last}" class="hp-hero__path-current" th:text="${crumb.name}">Current</span>
+                </th:block>
+            </nav>
 
             <!-- Topic Tags -->
             <div class="hp-tags" th:if="${hadith.topicTags != null and !hadith.topicTags.isEmpty()}">
@@ -187,10 +189,31 @@
                     onclick="toggleHadithNotes()">Show more</button>
         </div>
 
-        <!-- Back to search -->
-        <a href="/" class="hp-back">
-            <i class="fa fa-arrow-left" aria-hidden="true"></i> Search more hadith
-        </a>
+        <!-- Related narrations. The pre-computed LLM-judged pairs were already in the
+             index and reachable only over an XHR a crawler never makes; rendered here
+             they become the internal link graph the corpus never had. -->
+        <section class="hp-related" th:if="${!#lists.isEmpty(similar)}">
+            <h2 class="hp-related__title">Similar narrations</h2>
+            <ul class="hp-related__list">
+                <li th:each="item : ${similar}">
+                    <a th:href="${item.url}" th:text="${item.label}">Al-Kafi #1</a>
+                    <span class="hp-related__excerpt" th:text="${item.excerpt}">Excerpt</span>
+                </li>
+            </ul>
+        </section>
+
+        <div class="hp-onward">
+            <a th:if="${chapterUrl != null}" th:href="${chapterUrl}" class="hp-back">
+                <i class="fa fa-list" aria-hidden="true"></i>
+                <span th:text="'All narrations in ' + ${hadith.chapter}">All narrations in this chapter</span>
+            </a>
+            <a href="/books" class="hp-back">
+                <i class="fa fa-book" aria-hidden="true"></i> Browse all books
+            </a>
+            <a href="/" class="hp-back">
+                <i class="fa fa-arrow-left" aria-hidden="true"></i> Search more hadith
+            </a>
+        </div>
     </article>
 </main>
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -124,7 +124,7 @@
 <main class="container py-3">
 
 <h1 class="visually-hidden">Shia Hadith Database &mdash; Search 32,000+ Narrations of the Ahlul Bayt in Arabic and English</h1>
-<section id="welcome"></section>
+<section id="welcome"><div th:replace="~{fragments/home-content :: body}"></div></section>
 
 <section id="hadithView" class="mb-4" v-cloak>
     <div class="hadith-layout">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -3,20 +3,28 @@
 
 <head>
     <meta charset="UTF-8"/>
-    <title>HDP - The Hadith Database | Search 32,000+ Narrations in Arabic &amp; English</title>
-    <meta name="description" content="Search over 32,000 hadith narrations in Arabic and English. Browse Al-Kafi, Nahj al-Balagha, Ghurar al-Hikam and more. Find similar narrations and Quranic insights."/>
-    <meta name="keywords" content="shia hadith, hadith database, shia hadith search, islamic narrations, al-kafi, nahj al-balagha, ghurar al-hikam, ahlul bayt hadith, arabic english hadith"/>
+    <title th:text="${seoTitle}">Shia Hadith Database — Search 32,000+ Narrations in Arabic &amp; English</title>
+    <meta name="description" th:content="${seoDescription}" content="Search 32,000+ Shia hadith in Arabic and English. Browse Al-Kafi, Nahj al-Balagha, Man La Yahduruh al-Faqih and more, with similar narrations and Quranic insights."/>
     <meta name="author" content="Academy for Learning Islam"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
-    <link rel="canonical" href="/"/>
+    <!-- Absolute, and always on the canonical host: rewayaat.info mirrors this app, and a
+         relative "/" made the mirror declare itself canonical, splitting the site in two. -->
+    <link rel="canonical" th:href="${canonicalUrl}" href="https://hadith.academyofislam.com/"/>
+    <!-- Search result pages are thin and unbounded; they consolidate onto the home page. -->
+    <meta th:if="${robotsDirective != null}" name="robots" th:content="${robotsDirective}"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="HDP - The Hadith Database"/>
-    <meta property="og:title" content="HDP - The Hadith Database"/>
-    <meta property="og:description" content="Search over 32,000 hadith narrations in Arabic and English. Browse Al-Kafi, Nahj al-Balagha, and more with similar narrations and Quranic insights."/>
-    <meta property="og:url" content="https://rewayaat.info/"/>
-    <meta name="twitter:card" content="summary"/>
-    <meta name="twitter:title" content="HDP - The Hadith Database"/>
-    <meta name="twitter:description" content="Search over 32,000 hadith narrations in Arabic and English."/>
+    <meta property="og:title" th:content="${seoTitle}" content="Shia Hadith Database — Search 32,000+ Narrations in Arabic &amp; English"/>
+    <meta property="og:description" th:content="${seoDescription}" content="Search 32,000+ Shia hadith in Arabic and English. Browse Al-Kafi, Nahj al-Balagha and more."/>
+    <meta property="og:url" th:content="${canonicalUrl}" content="https://hadith.academyofislam.com/"/>
+    <meta property="og:image" content="https://hadith.academyofislam.com/img/share-card.png"/>
+    <meta property="og:image:width" content="1200"/>
+    <meta property="og:image:height" content="630"/>
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:title" th:content="${seoTitle}" content="Shia Hadith Database — Search 32,000+ Narrations in Arabic &amp; English"/>
+    <meta name="twitter:description" th:content="${seoDescription}" content="Search 32,000+ Shia hadith in Arabic and English."/>
+    <meta name="twitter:image" content="https://hadith.academyofislam.com/img/share-card.png"/>
+    <script type="application/ld+json" th:utext="${jsonLd}"></script>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin/>
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
@@ -115,7 +123,7 @@
 
 <main class="container py-3">
 
-<h1 class="visually-hidden">HDP - The Hadith Database: Search 32,000+ Narrations in Arabic and English</h1>
+<h1 class="visually-hidden">Shia Hadith Database &mdash; Search 32,000+ Narrations of the Ahlul Bayt in Arabic and English</h1>
 <section id="welcome"></section>
 
 <section id="hadithView" class="mb-4" v-cloak>

--- a/src/main/resources/templates/volume.html
+++ b/src/main/resources/templates/volume.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/site :: head}"></head>
+<body>
+<nav th:replace="~{fragments/site :: nav}"></nav>
+
+<main class="container py-3">
+    <nav th:replace="~{fragments/site :: crumbs}"></nav>
+
+    <header class="hub-hero">
+        <h1 class="hub-hero__title">
+            <span th:text="${book.name}">Book</span> &mdash; <span th:text="${volumeLabel}">Volume 1</span>
+        </h1>
+        <p class="hub-hero__lede">
+            <strong th:text="${#numbers.formatInteger(narrationCount, 0, 'COMMA')}">1,000</strong> narrations
+            across <span th:text="${#numbers.formatInteger(#lists.size(chapters), 0, 'COMMA')}">100</span>
+            chapters, in Arabic and English.
+        </p>
+    </header>
+
+    <section>
+        <h2 class="hub-group__label">Chapters</h2>
+        <ul class="hub-list">
+            <li th:each="chapter : ${chapters}">
+                <a th:href="${chapter.url}" th:text="${chapter.title}">Chapter title</a>
+                <span class="hub-list__count" th:text="'(' + ${chapter.count} + ')'">(12)</span>
+            </li>
+        </ul>
+    </section>
+</main>
+
+<footer th:replace="~{fragments/site :: footer}"></footer>
+<th:block th:replace="~{fragments/site :: analytics}"></th:block>
+</body>
+</html>

--- a/src/main/resources/templates/volume.html
+++ b/src/main/resources/templates/volume.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/site :: head}"></head>
+<head th:replace="~{fragments/site :: sitehead}"></head>
 <body>
-<nav th:replace="~{fragments/site :: nav}"></nav>
+<nav th:replace="~{fragments/site :: sitenav}"></nav>
 
 <main class="container py-3">
-    <nav th:replace="~{fragments/site :: crumbs}"></nav>
+    <nav th:replace="~{fragments/site :: crumbtrail}"></nav>
 
     <header class="hub-hero">
         <h1 class="hub-hero__title">
@@ -29,7 +29,7 @@
     </section>
 </main>
 
-<footer th:replace="~{fragments/site :: footer}"></footer>
+<footer th:replace="~{fragments/site :: sitefooter}"></footer>
 <th:block th:replace="~{fragments/site :: analytics}"></th:block>
 </body>
 </html>

--- a/src/test/java/com/rewayaat/controllers/HomeControllerTest.java
+++ b/src/test/java/com/rewayaat/controllers/HomeControllerTest.java
@@ -5,6 +5,8 @@ import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HomeControllerTest {
 
@@ -19,6 +21,62 @@ class HomeControllerTest {
         assertEquals("query", model.getAttribute("query"));
         assertEquals(2, model.getAttribute("page"));
         assertEquals("book:asc", model.getAttribute("sort_fields"));
+    }
+
+    /**
+     * The home page is the site's candidate for "shia hadith", and used to open its title
+     * with "HDP" while never using the word "Shia" outside an ignored keywords meta.
+     */
+    @Test
+    void home_titleAndDescriptionCarryTheTargetPhrase() {
+        Model model = new ExtendedModelMap();
+
+        new HomeController().home("", 1, null, null, model);
+
+        String title = (String) model.getAttribute("seoTitle");
+        String description = (String) model.getAttribute("seoDescription");
+        assertTrue(title.toLowerCase().startsWith("shia hadith"),
+                "title should lead with the target phrase, was: " + title);
+        assertTrue(description.toLowerCase().contains("shia hadith"),
+                "description should contain the target phrase, was: " + description);
+    }
+
+    /**
+     * A relative canonical resolves against whichever host served the page, so the
+     * rewayaat.info mirror was declaring itself canonical instead of consolidating.
+     */
+    @Test
+    void home_canonicalIsAbsoluteAndOnTheCanonicalHost() {
+        Model model = new ExtendedModelMap();
+
+        new HomeController().home("", 1, null, null, model);
+
+        assertEquals("https://hadith.academyofislam.com/", model.getAttribute("canonicalUrl"));
+    }
+
+    @Test
+    void home_publishesWebsiteAndOrganizationStructuredData() {
+        Model model = new ExtendedModelMap();
+
+        new HomeController().home("", 1, null, null, model);
+
+        String jsonLd = (String) model.getAttribute("jsonLd");
+        assertTrue(jsonLd.contains("\"WebSite\""), "expected WebSite node");
+        assertTrue(jsonLd.contains("SearchAction"), "expected a sitelinks SearchAction");
+        assertTrue(jsonLd.contains("Organization"), "expected an Organization node");
+    }
+
+    /** Search result pages are thin and unbounded; only the bare home page is indexable. */
+    @Test
+    void home_searchResultPagesAreNoindexed() {
+        Model bare = new ExtendedModelMap();
+        Model search = new ExtendedModelMap();
+
+        new HomeController().home("", 1, null, null, bare);
+        new HomeController().home("prayer", 1, null, null, search);
+
+        assertNull(bare.getAttribute("robotsDirective"));
+        assertEquals("noindex, follow", search.getAttribute("robotsDirective"));
     }
 
     @Test

--- a/src/test/java/com/rewayaat/controllers/HomeControllerTest.java
+++ b/src/test/java/com/rewayaat/controllers/HomeControllerTest.java
@@ -1,5 +1,6 @@
 package com.rewayaat.controllers;
 
+import com.rewayaat.service.BookCatalog;
 import org.junit.jupiter.api.Test;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
@@ -10,9 +11,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HomeControllerTest {
 
+    /** The catalog is only read for the rendered book list; an empty one is enough here. */
+    private static HomeController controller() {
+        return new HomeController(new BookCatalog());
+    }
+
     @Test
     void home_populatesModelAttributes() {
-        HomeController controller = new HomeController();
+        HomeController controller = controller();
         Model model = new ExtendedModelMap();
 
         String view = controller.home("query", 2, "book:asc", null, model);
@@ -31,7 +37,7 @@ class HomeControllerTest {
     void home_titleAndDescriptionCarryTheTargetPhrase() {
         Model model = new ExtendedModelMap();
 
-        new HomeController().home("", 1, null, null, model);
+        controller().home("", 1, null, null, model);
 
         String title = (String) model.getAttribute("seoTitle");
         String description = (String) model.getAttribute("seoDescription");
@@ -49,7 +55,7 @@ class HomeControllerTest {
     void home_canonicalIsAbsoluteAndOnTheCanonicalHost() {
         Model model = new ExtendedModelMap();
 
-        new HomeController().home("", 1, null, null, model);
+        controller().home("", 1, null, null, model);
 
         assertEquals("https://hadith.academyofislam.com/", model.getAttribute("canonicalUrl"));
     }
@@ -58,7 +64,7 @@ class HomeControllerTest {
     void home_publishesWebsiteAndOrganizationStructuredData() {
         Model model = new ExtendedModelMap();
 
-        new HomeController().home("", 1, null, null, model);
+        controller().home("", 1, null, null, model);
 
         String jsonLd = (String) model.getAttribute("jsonLd");
         assertTrue(jsonLd.contains("\"WebSite\""), "expected WebSite node");
@@ -72,8 +78,8 @@ class HomeControllerTest {
         Model bare = new ExtendedModelMap();
         Model search = new ExtendedModelMap();
 
-        new HomeController().home("", 1, null, null, bare);
-        new HomeController().home("prayer", 1, null, null, search);
+        controller().home("", 1, null, null, bare);
+        controller().home("prayer", 1, null, null, search);
 
         assertNull(bare.getAttribute("robotsDirective"));
         assertEquals("noindex, follow", search.getAttribute("robotsDirective"));
@@ -81,7 +87,7 @@ class HomeControllerTest {
 
     @Test
     void verifyRedirect_sendsTokenToSigninPage() {
-        HomeController controller = new HomeController();
+        HomeController controller = controller();
 
         String redirect = controller.verifyRedirect("abc123");
 
@@ -90,7 +96,7 @@ class HomeControllerTest {
 
     @Test
     void resetRedirect_sendsTokenToSigninPage() {
-        HomeController controller = new HomeController();
+        HomeController controller = controller();
 
         String redirect = controller.resetRedirect("abc123");
 

--- a/src/test/java/com/rewayaat/service/BookCatalogSlugTest.java
+++ b/src/test/java/com/rewayaat/service/BookCatalogSlugTest.java
@@ -1,0 +1,63 @@
+package com.rewayaat.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Slugs are public URLs, so they are load-bearing: a change here silently 404s every
+ * book and chapter page Google has indexed. These pin the shape rather than the
+ * implementation.
+ */
+class BookCatalogSlugTest {
+
+    /**
+     * Book titles are transliterated Arabic full of combining marks. Stripping them
+     * gives the plain-ASCII spelling people type and link to.
+     */
+    @Test
+    void slugify_stripsTransliterationDiacritics() {
+        assertEquals("al-kafi", BookCatalog.slugify("Al-Kāfi"));
+        assertEquals("man-la-yahduruh-al-faqih", BookCatalog.slugify("Man Lā Yaḥḍuruh al-Faqīh"));
+        assertEquals("nahj-al-balagha", BookCatalog.slugify("Nahj al-Balāgha"));
+        assertEquals("uyun-akhbar-al-rida", BookCatalog.slugify("ʿUyūn akhbār al-Riḍā"));
+        assertEquals("al-khisal", BookCatalog.slugify("Al-Khiṣāl"));
+    }
+
+    /**
+     * book_blurbs.json spells its books differently from Elasticsearch; the two are
+     * matched on the slug, so the two spellings have to converge on it.
+     */
+    @Test
+    void slugify_foldsTheBlurbFileSpellingOntoTheIndexSpelling() {
+        assertEquals(BookCatalog.slugify("Al-Kāfi"), BookCatalog.slugify("AL-KAFI"));
+        assertEquals(BookCatalog.slugify("Nahj al-Balāgha"), BookCatalog.slugify("Nahj Al-Balagha"));
+        assertEquals(BookCatalog.slugify("Kāmil al-Ziyārāt"), BookCatalog.slugify("Kamil Al-Ziyarat"));
+    }
+
+    @Test
+    void slugify_producesUrlSafeOutput() {
+        String slug = BookCatalog.slugify("The Imams (a.s.) are the Only True Guides — 'Chapter 3'");
+
+        assertTrue(slug.matches("[a-z0-9-]+"), "slug had unsafe characters: " + slug);
+        assertTrue(!slug.startsWith("-") && !slug.endsWith("-"), "slug had dangling separators: " + slug);
+    }
+
+    /** Chapter titles run long; an unbounded slug makes an unusable URL. */
+    @Test
+    void slugify_capsLengthWithoutLeavingATrailingSeparator() {
+        String slug = BookCatalog.slugify("Enlightening points deduced from the Holy Quran about "
+                + "leadership with divine authority and the necessity of obedience to the Imams");
+
+        assertTrue(slug.length() <= 80, "slug was " + slug.length() + " chars: " + slug);
+        assertTrue(!slug.endsWith("-"), "slug ended with a separator: " + slug);
+    }
+
+    @Test
+    void slugify_handlesNullAndEmpty() {
+        assertEquals("", BookCatalog.slugify(null));
+        assertEquals("", BookCatalog.slugify("   "));
+        assertEquals("", BookCatalog.slugify("!!!"));
+    }
+}


### PR DESCRIPTION
Three commits addressing the same root problem: **nothing linked to the narration pages.** They were reachable only from the XML sitemap, so none of the site's authority reached any of them, and no URL on the site could rank for a book name like "al-kafi" or "nahj al-balagha".

## What changed

**`c6521c6` — home page targeting.** The site's candidate page for "shia hadith" never used the phrase — not in the title (which opened with the acronym "HDP"), the description, or the H1. The only on-page use was a `keywords` meta, which Google has ignored since 2009.

It also fixes a live canonical bug: `<link rel="canonical" href="/">` is relative, so it resolves against whichever host served the page. `rewayaat.info` mirrors this app, so **the mirror was declaring itself canonical** and the two domains were competing for the same rankings. `og:url` was separately pointing at the mirror. Both are now absolute and pinned to the canonical host.

Adds site-level JSON-LD (`WebSite` with a `SearchAction`, `Organization`), and `noindex, follow` on `/?q=…` result pages, which are thin and unbounded.

**`3876191` — the hub pages the site never had.** Four server-rendered levels: `/books` → `/books/{book}` → `/books/{book}/volume/{n}` → `/books/{book}/{chapter}`, ending in real `<a href>` links to narrations. Server-rendered because the rest of the site builds content over XHR, and a crawler that doesn't run scripts sees an empty shell.

`BookCatalog` holds the structure from one composite aggregation, refreshed every six hours — aggregating per request would put an ES round trip in front of every crawler hit. Slugs strip transliteration diacritics, so *Man Lā Yaḥḍuruh al-Faqīh* answers at `/books/man-la-yahduruh-al-faqih`, the spelling people actually type.

Volumes are their own level rather than sections of the book page: Al-Kāfi alone has 2,693 chapters, and inlining them made a 637 KB page with 2,693 outbound links.

**`3a21933` — linking the narrations up and sideways.** A narration page's only internal links were three copies of `/` plus the footer; it named its book, volume and chapter in `<span>`s and linked to none of them. The breadcrumb spans are now a real linked trail, with a `BreadcrumbList` built from the same list so the two can't disagree.

The pre-computed LLM-judged similar narrations are now rendered as links. **47,522 judged-similar pairs were already in the index** and reachable only over an XHR no crawler makes — and they cross book boundaries, which is exactly the graph that was missing.

## Verification

Clean build from an isolated worktree at `3a21933` (not a dev tree), against the live local index.

- **Build:** SUCCESS. **Boots:** 9s, no startup errors. **Tests:** 434 run, **0 failures** (new `BookCatalogSlugTest` 5/5, `HomeControllerTest` extended).

Routes and page weight — the split keeps every page in the chain small:

| URL | status | size | links |
|---|---|---|---|
| `/books` | 200 | 18 KB | 31 |
| `/books/al-kafi` | 200 | 15 KB | 23 |
| `/books/al-kafi/volume/1` | 200 | 63 KB | **206** |
| `/books/al-kafi/introduction` | 200 | 11 KB | 19 |
| `/hadith/Al-Kafi-Volume-1-Kulayni:82` | 200 | 20 KB | **22** (was 3 + footer) |

18 books listed on `/books`; the 637 KB / 2,693-link page is gone, max is 206.

Rendered markup, checked in the HTML rather than the source:

| page | title | canonical | robots |
|---|---|---|---|
| home | `Shia Hadith Database — Search 32,000+ Narrations…` | `https://hadith.academyofislam.com/` | — |
| `/?q=prayer` | same | canonical host | **`noindex, follow`** |
| narration | `Al-Kāfi #82 — Shia Hadith in Arabic & English` | absolute, self | — |

JSON-LD present: `WebSite` + `Organization` on the home page, `BreadcrumbList` on the narration page. No "HDP" in any title.

`sitemap.xml` gains `/sitemap-books.xml` — **7,885 hub URLs** — alongside the four hadith pages, which still total 32,519.

**No regressions** in what was verified after #76/#69: home, search, hadith detail and both sitemap routes still 200, and the #77 fix holds (`/this-page-does-not-exist` and `/v1/nonexistent` both 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzZ7NtYnRgYxvotL6URw9K