### PR TITLE
fix(k8s): spread the two replicas across nodes so the PDB means something

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -13,6 +13,30 @@ spec:
       labels:
         app: rewayaat-v2
     spec:
+      # Both replicas ran on one node until now, which made replicas: 2 and the
+      # minAvailable: 1 PDB decorative: a single node failure took the whole app out,
+      # and a node drain had nowhere to move the second pod to.
+      #
+      # DoNotSchedule rather than ScheduleAnyway, because a preference is exactly what
+      # failed here -- the scheduler discards it the moment the preferred node is the
+      # cheaper fit, which is how both pods ended up co-located. maxSkew: 1 still allows
+      # two pods per node once every node already has one, so an HPA scale to 4 across
+      # fewer nodes is not blocked; it only forbids stacking while a node sits empty.
+      #
+      # nodeTaintsPolicy: Honor is what makes this drain-safe. The default (Ignore)
+      # counts cordoned nodes as valid domains, so during a drain the evicted node still
+      # looks like somewhere a pod ought to go, and the skew maths can refuse to place
+      # the replacement anywhere -- the pod stays Pending and the drain stalls on the
+      # PDB. Honor excludes nodes whose NoSchedule taint the pod does not tolerate,
+      # which is precisely what cordon adds.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          nodeTaintsPolicy: Honor
+          labelSelector:
+            matchLabels:
+              app: rewayaat-v2
       containers:
         - name: rewayaat-v2
           # Overridden by k8s/kustomization.yaml images.newTag during GitOps deploys.


### PR DESCRIPTION
Both `rewayaat-v2` replicas were running on the **same node** (`k8s-c1-default-pool-37z2fm`):

```
rewayaat-v2-...-pj9lx   1/1   Running   k8s-c1-default-pool-37z2fm
rewayaat-v2-...-s87mn   1/1   Running   k8s-c1-default-pool-37z2fm
```

So `replicas: 2` and the `minAvailable: 1` PDB looked like HA and were not — one node failure takes the whole app down, and a node drain has nowhere to move the second pod.

## Why this form

**`DoNotSchedule`, not `ScheduleAnyway`** — a preference is exactly what failed here. The scheduler discards a soft rule the moment the preferred node is the cheaper fit, which is how both pods ended up co-located. `maxSkew: 1` still allows two pods per node *once every node already has one*, so an HPA scale to 4 across fewer nodes isn't blocked; it only forbids stacking while a node sits empty.

**`nodeTaintsPolicy: Honor`** is what makes this drain-safe, and is the part worth not dropping. The default (`Ignore`) counts cordoned nodes as valid domains — so during a drain the evicted node still looks like somewhere a pod ought to go, and the skew maths can refuse to place the replacement anywhere. The pod stays `Pending` and the drain stalls on the PDB. `Honor` excludes nodes whose `NoSchedule` taint the pod doesn't tolerate, which is precisely what `cordon` adds. Needs 1.27+; the cluster is **1.33.12**.

Chose this over `requiredDuringScheduling` podAntiAffinity because required anti-affinity caps the app at one pod per node — with `maxReplicas: 4` and 4 nodes, any node loss would hard-block a scale-up. Topology spread degrades to 2-per-node instead.

## Rollout

Pod-template change, so a rolling update. With 2 replicas, `maxUnavailable: 25%` floors to 0 and `maxSurge: 25%` ceils to 1 — it surges a new pod before removing an old one, so no request loss, and the new pod lands on a different node.

Verified with `kubectl apply --dry-run=server`: accepted.

Context: prompted by a node-pool migration in `cloud-infra` (hadi-technology/cloud-infra#36) that drains the current intel nodes onto a new pool. Without this, that drain takes rewayaat fully down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQc29XtSnxSiXRZq3yHYUu