### PR TITLE
fix: give editors the pencil back on server-rendered pages

### DIFF
--- a/src/main/java/com/rewayaat/controllers/HomeController.java
+++ b/src/main/java/com/rewayaat/controllers/HomeController.java
@@ -138,8 +138,24 @@ public class HomeController {
         if (id != null && !id.isBlank()) {
             model.addAttribute("hadithId", id);
         }
-        model.addAttribute("returnTo", returnTo != null ? returnTo : "/");
+        model.addAttribute("returnTo", safeReturnTo(returnTo));
         return "edit";
+    }
+
+    /**
+     * The editor navigates to this value after a successful save, so anything that is
+     * not a path on this site is an open redirect. Site-relative paths only: a leading
+     * slash, but not a protocol-relative "//host" and not a "/\host" that some browsers
+     * normalise the same way.
+     */
+    static String safeReturnTo(String returnTo) {
+        if (returnTo == null || returnTo.isBlank() || returnTo.charAt(0) != '/') {
+            return "/";
+        }
+        if (returnTo.length() > 1 && (returnTo.charAt(1) == '/' || returnTo.charAt(1) == '\\')) {
+            return "/";
+        }
+        return returnTo;
     }
 
     private String redirectToSigninWithToken(String queryKey, String token) {

--- a/src/main/resources/static/js/hub-pages.js
+++ b/src/main/resources/static/js/hub-pages.js
@@ -45,12 +45,32 @@
         if (shell) { shell.classList.toggle('d-none', !authed); }
 
         if (authed && authState.user) {
-            var label = authState.user.name || authState.user.email || 'Account';
+            // The payload from /v1/auth/me calls it displayName, the same field the
+            // search app reads. Reading `name` here left every editor labelled by email.
+            var label = authState.user.displayName || authState.user.email || 'Account';
             if (name) { name.textContent = label; }
             if (initial) { initial.textContent = label.charAt(0).toUpperCase(); }
         }
         document.querySelectorAll('[data-requires-auth]').forEach(function (node) {
             node.classList.toggle('is-signed-out', !authed);
+        });
+        applyEditorState(authed && !!(authState.user && authState.user.canEditHadith));
+    }
+
+    /**
+     * The edit pencil ships hidden and stays hidden for everyone the server does not
+     * name as an editor. Revealing it also stamps the current page into returnTo, so
+     * /edit sends the editor back to the chapter or narration they came from rather
+     * than to the search page.
+     */
+    function applyEditorState(canEdit) {
+        var here = window.location.pathname + window.location.search;
+        document.querySelectorAll('[data-edit-hadith]').forEach(function (node) {
+            node.classList.toggle('d-none', !canEdit);
+            if (!canEdit) { return; }
+            node.setAttribute('href', '/edit?id='
+                + encodeURIComponent(node.getAttribute('data-edit-hadith'))
+                + '&returnTo=' + encodeURIComponent(here));
         });
     }
 

--- a/src/main/resources/templates/fragments/hadith-card.html
+++ b/src/main/resources/templates/fragments/hadith-card.html
@@ -136,11 +136,12 @@
                            th:href="${tag.url}" th:text="${tag.label}">tag</a>
                     </div>
 
-                    <!-- The same actions the search card offers, minus the two that only
-                         make sense inside the app: editing (needs editor access) and
-                         removing from a collection (only meaningful in collection view).
-                         The dropdowns are driven by hub-pages.js rather than Bootstrap's
-                         JS, so these pages do not pull the bundle in for two menus. -->
+                    <!-- The same actions the search card offers, minus removing from a
+                         collection, which is only meaningful in collection view. Editing
+                         is here too, hidden until /v1/auth/me says the reader may edit;
+                         it links to the standalone /edit page rather than the search
+                         app's modal. The dropdowns are driven by hub-pages.js rather than
+                         Bootstrap's JS, so these pages do not pull the bundle in. -->
                     <div class="d-flex flex-wrap gap-2 hadith-header-actions hadith-card__actions">
                         <div class="dropdown hadith-copy-dropdown hub-menu">
                             <button class="icon-action icon-action--copy hadith-copy-trigger"
@@ -170,6 +171,13 @@
                                 aria-label="Save hadith" title="Save to collection">
                             <i class="fa fa-bookmark" aria-hidden="true"></i>
                         </button>
+
+                        <a class="icon-action icon-action--edit d-none"
+                           th:attr="data-edit-hadith=${narration.id}"
+                           th:href="@{/edit(id=${narration.id})}"
+                           aria-label="Edit hadith" title="Edit hadith">
+                            <i class="fa fa-pencil" aria-hidden="true"></i>
+                        </a>
 
                         <a class="icon-action icon-action--report" target="_blank" rel="noopener noreferrer"
                            th:href="${narration.reportHref}"

--- a/src/test/java/com/rewayaat/controllers/HadithCardParityTest.java
+++ b/src/test/java/com/rewayaat/controllers/HadithCardParityTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -104,6 +105,20 @@ class HadithCardParityTest {
             "hadith-copy-dropdown",           // copy menu
             "hadith-inline-context");         // the Related / Tafsir inline panels
 
+    /**
+     * Actions the search card carries that cannot mean anything on a server-rendered
+     * page. Removing from a collection needs a collection to be open; nothing else
+     * belongs here, and editing notably does not — it links to /edit.
+     */
+    private static final Set<String> SEARCH_ONLY_ACTIONS = Set.of("remove");
+
+    /**
+     * Menu entries the search card offers that are not the card's to mirror. Exporting
+     * a PDF is a page-level action on the hub pages, reached from the chapter toolbar
+     * rather than from a narration's copy menu.
+     */
+    private static final Set<String> SEARCH_ONLY_MENU_ITEMS = Set.of("Export PDF");
+
     @Test
     void serverCardCarriesEveryStructuralClassTheSearchCardDoes() throws IOException {
         String index = readSearchCard();
@@ -140,6 +155,84 @@ class HadithCardParityTest {
 
         assertTrue(extra.isEmpty(),
                 "The server card uses structural classes the search card does not: " + extra);
+    }
+
+    /**
+     * The action rail is where a missing class costs a reader something they can name.
+     * The list above is hand-maintained, so it only catches drift somebody remembered
+     * to enumerate: the edit pencil went missing from the server card for an entire
+     * release because {@code icon-action--edit} was never added to {@link #STRUCTURAL}.
+     * This test derives the modifiers from the search card instead, so a new action
+     * button has to be mirrored or excused on purpose.
+     */
+    @Test
+    void everyCardActionIsOfferedOnServerRenderedPagesToo() throws IOException {
+        Set<String> searchActions = actionModifiers(readSearchCard());
+        Set<String> serverActions = actionModifiers(read(SERVER_CARD));
+
+        assertFalse(searchActions.isEmpty(), "found no icon-action modifiers in the search card");
+
+        Set<String> missing = new LinkedHashSet<>(searchActions);
+        missing.removeAll(serverActions);
+        missing.removeAll(SEARCH_ONLY_ACTIONS);
+
+        assertTrue(missing.isEmpty(),
+                "The search card offers these actions and the server card does not: " + missing
+                        + "\nAdd them to fragments/hadith-card.html, or to SEARCH_ONLY_ACTIONS "
+                        + "with a reason if they cannot work outside the search app.");
+    }
+
+    /**
+     * The copy and share menus are the other half of the rail, and the same blind spot
+     * applies: a "Copy image" added to one card and not the other reads as a feature
+     * that works everywhere until somebody opens a chapter page. Labels are compared
+     * because they are what the reader is promised, and both cards write them as plain
+     * text in the same place.
+     */
+    @Test
+    void everyCardMenuItemIsOfferedOnServerRenderedPagesToo() throws IOException {
+        Set<String> searchItems = copyMenuItems(readSearchCard());
+        Set<String> serverItems = copyMenuItems(read(SERVER_CARD));
+
+        assertFalse(searchItems.isEmpty(), "found no copy-menu items in the search card");
+
+        Set<String> missing = new LinkedHashSet<>(searchItems);
+        missing.removeAll(serverItems);
+        missing.removeAll(SEARCH_ONLY_MENU_ITEMS);
+
+        assertTrue(missing.isEmpty(),
+                "The search card's copy and share menus offer these and the server card does not: "
+                        + missing + "\nMirror them in fragments/hadith-card.html, or add them to "
+                        + "SEARCH_ONLY_MENU_ITEMS with a reason.");
+    }
+
+    /** The visible labels of every dropdown item inside a hadith-copy-menu. */
+    private static Set<String> copyMenuItems(String html) {
+        Set<String> found = new LinkedHashSet<>();
+        Matcher menu = Pattern.compile(
+                "<ul[^>]*hadith-copy-menu[^>]*>(.*?)</ul>", Pattern.DOTALL).matcher(html);
+        while (menu.find()) {
+            Matcher item = Pattern.compile(
+                    "<button[^>]*class=\"dropdown-item\"[^>]*>(.*?)</button>",
+                    Pattern.DOTALL).matcher(menu.group(1));
+            while (item.find()) {
+                String label = item.group(1).replaceAll("<[^>]*>", " ")
+                        .replaceAll("\\s+", " ").trim();
+                if (!label.isEmpty()) {
+                    found.add(label);
+                }
+            }
+        }
+        return found;
+    }
+
+    private static Set<String> actionModifiers(String html) {
+        Set<String> found = new LinkedHashSet<>();
+        Matcher m = Pattern.compile("icon-action--([a-z][a-z-]*)").matcher(html);
+        while (m.find()) {
+            found.add(m.group(1));
+        }
+        return found;
     }
 
     /** The classes the whole scheme rests on; if these vanish the sharing is over. */

--- a/src/test/java/com/rewayaat/controllers/HomeControllerTest.java
+++ b/src/test/java/com/rewayaat/controllers/HomeControllerTest.java
@@ -102,4 +102,19 @@ class HomeControllerTest {
 
         assertEquals("redirect:/signin.html?reset_token=abc123", redirect);
     }
+
+    @Test
+    void editReturnToAcceptsSitePathsAndRejectsEverythingElse() {
+        assertEquals("/hadith/Al-Kafi-Volume-1-Kulayni:2",
+                HomeController.safeReturnTo("/hadith/Al-Kafi-Volume-1-Kulayni:2"));
+        assertEquals("/books/al-kafi?tag=prayer", HomeController.safeReturnTo("/books/al-kafi?tag=prayer"));
+
+        // The editor is sent here after saving, so an off-site value is an open redirect.
+        assertEquals("/", HomeController.safeReturnTo("https://evil.example/"));
+        assertEquals("/", HomeController.safeReturnTo("//evil.example/"));
+        assertEquals("/", HomeController.safeReturnTo("/\\evil.example/"));
+        assertEquals("/", HomeController.safeReturnTo("javascript:alert(1)"));
+        assertEquals("/", HomeController.safeReturnTo(null));
+        assertEquals("/", HomeController.safeReturnTo("  "));
+    }
 }


### PR DESCRIPTION
Editors on the allowlist lost the ability to edit narrations when chapters and volumes started routing to the server-rendered pages. The search card gates its pencil on `canEditHadith`; the shared fragment simply never had one. A comment in the fragment justified the omission — editing "needs editor access" — as though that were a reason to leave it out, when the search card shows the gate is the answer.

## The fix

The pencil ships in the fragment hidden, and `hub-pages.js` reveals it for the same `canEditHadith` flag `rewayaat.js` reads. It links to `/edit` with the current path in `returnTo`.

That link is not a new editing experience. `openNarrationEditor` in search mode does exactly this:

```js
window.location.href = '/edit?id=' + encodeURIComponent(hadithId)
    + '&returnTo=' + encodeURIComponent(window.location.pathname + window.location.search);
```

which is character-for-character what the static card now builds. Same page, same form, same `PUT /v1/narrations/{id}`. There was no second editor to keep in sync — these pages were just missing the link to the one that already existed. (`openHadithEditorModal()` in `rewayaat.js`, ~200 lines, has zero callers and is dead; not touched here.)

The `PUT` endpoint checks the allowlist itself, so the hidden pencil is an affordance, not a boundary.

## Verified

Driving a headless browser with `/v1/auth/me` stubbed, so this is the gate running rather than markup being present:

| | pencils in DOM | visible |
|---|---|---|
| allowlisted editor, chapter page | 36 | **36** |
| signed-in reader, same page | 36 | **0** |
| editor, single narration page | 1 | **1** |

36 pencils to 36 save buttons — one per card. Then confirmed against a real session, not the stub: `/v1/auth/me` returns `canEditHadith: true`, and `/edit?id=…&returnTo=…` returns 200 with the narration loaded.

## Two more bugs, found on the way

- **`hub-pages.js` read `authState.user.name`**, which `/v1/auth/me` has never sent — it sends `displayName`. Every signed-in reader was labelled by their email address in the nav on these pages.
- **`/edit` passed `returnTo` straight to `window.location.href` unvalidated.** `?returnTo=https://evil.example/` sent an editor off-site after a successful save. Reachable from search mode too, since it builds the same link. Site-relative paths only now, with `//host` and `/\host` rejected.

## Why the parity test missed it

`HadithCardParityTest` compares a **hand-written list** of class names. `icon-action--edit` was never on that list, so the test stayed green through the entire regression — it could only ever catch drift somebody had already thought to enumerate.

It now derives two things from the search card instead:

- **`icon-action--*` modifiers** — every action button must be mirrored or excused. Only `remove` is excused (needs an open collection).
- **copy and share menu labels** — every entry must be mirrored or excused. Only `Export PDF` is excused (page-level on hub pages, not per-card).

Both were checked red before the corresponding fix and green after; the three pre-existing tests pass in both states, which is what shows the old suite was blind.

The menu half is not hypothetical: #81 adds "Copy image (dark)" and "Copy image (light)" to the share menu. That branch mirrored them correctly by hand, and this test is what will keep the next one honest.

## Notes

- **474 tests, 0 failures.**
- Merges cleanly with `feat/hadith-share-cards` (#81) in either order — verified by merging locally and running the combined suite: **458 tests, 0 failures**, with the new menu test validating that branch's two new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Kf8GvvPA3hFCjFUkJx8zs
