### PR TITLE
Record the reader-reported translation corrections already applied to production

### DIFF
--- a/scripts/ops/apply_reported_corrections.py
+++ b/scripts/ops/apply_reported_corrections.py
@@ -7,6 +7,11 @@ only applied when its `old` string is found verbatim, so a document that has alr
 been corrected -- or that never matched -- is reported and skipped rather than
 guessed at.
 
+`mirror_fields` carries the same replacement into the derived fields that feed the
+embedding pipeline. semantic_english_hint_source is a separate stored copy of the
+first ~120 characters of the English, so correcting `english` alone leaves the
+embedding input describing the old wording.
+
 Dry run by default; pass --live to write.
 
 Usage:
@@ -43,8 +48,13 @@ def fetch(es_host, index, ids):
     return {d["_id"]: (d.get("_source") if d.get("found") else None) for d in docs}
 
 
-def plan_document(source, field, replacements):
-    """Return (new_value, applied, missing) for one document."""
+def plan_field(source, field, replacements, required):
+    """Return (new_value, applied, missing) for one field of one document.
+
+    `required` is False for mirror fields, where a replacement that does not
+    match is expected rather than a problem: the hint holds only the opening of
+    the English, so a correction further in simply is not there.
+    """
     original = source.get(field) or ""
     value = original
     applied, missing = [], []
@@ -57,7 +67,7 @@ def plan_document(source, field, replacements):
         elif old in value:
             value = value.replace(old, new)
             applied.append(old)
-        else:
+        elif required:
             missing.append((old, "not found"))
     return (value if value != original else None), applied, missing
 
@@ -81,23 +91,34 @@ def main():
 
     updates, skipped, problems = {}, [], []
 
+    mirrors = spec.get("mirror_fields", {})
+
     for entry in entries:
+        field = entry["field"]
+        targets = [(field, True)] + [(m, False) for m in mirrors.get(field, [])]
         for doc_id in entry["ids"]:
             source = sources.get(doc_id)
             if source is None:
                 problems.append((doc_id, "document not found"))
                 continue
-            new_value, applied, missing = plan_document(source, entry["field"], entry["replacements"])
-            for old, why in missing:
-                (skipped if why == "already applied" else problems).append(
-                    (doc_id, f"{why}: {old[:60]}"))
-            if new_value is not None:
-                updates[doc_id] = {"field": entry["field"], "value": new_value,
-                                   "kind": entry["kind"], "count": len(applied)}
+            for target, required in targets:
+                new_value, applied, missing = plan_field(
+                    source, target, entry["replacements"], required)
+                for old, why in missing:
+                    (skipped if why == "already applied" else problems).append(
+                        (doc_id, f"{target}: {why}: {old[:50]}"))
+                if new_value is not None:
+                    doc = updates.setdefault(doc_id, {"fields": {}, "kind": entry["kind"],
+                                                      "count": 0, "reindex": False})
+                    doc["fields"][target] = new_value
+                    doc["count"] += len(applied)
+                    if target != field:
+                        doc["reindex"] = True
 
     for doc_id, info in sorted(updates.items()):
-        flag = "  <-- REVIEW" if info["kind"] == "rewrite" else ""
-        print(f"  {doc_id:46} {info['kind']:10} {info['count']} edit(s){flag}")
+        flags = "  <-- REVIEW" if info["kind"] == "rewrite" else ""
+        flags += "  <-- RE-EMBED" if info["reindex"] else ""
+        print(f"  {doc_id:46} {info['kind']:10} {info['count']} edit(s){flags}")
 
     print(f"\n{len(updates)} document(s) to change, {len(skipped)} already correct, "
           f"{len(problems)} problem(s)")
@@ -116,7 +137,7 @@ def main():
     lines = []
     for doc_id, info in updates.items():
         lines.append(json.dumps({"update": {"_id": doc_id, "_index": args.index}}))
-        lines.append(json.dumps({"doc": {info["field"]: info["value"]}}, ensure_ascii=False))
+        lines.append(json.dumps({"doc": info["fields"]}, ensure_ascii=False))
     payload = ("\n".join(lines) + "\n").encode("utf-8")
 
     url = f"{args.es_host.rstrip('/')}/_bulk?refresh=true"
@@ -133,11 +154,18 @@ def main():
         return 1
 
     print(f"\nWrote {len(updates)} document(s) to {args.index} on {args.es_host}.")
+
+    reindex = sorted(d for d, i in updates.items() if i["reindex"])
     if args.ids_out:
-        args.ids_out.write_text("\n".join(sorted(updates)) + "\n", encoding="utf-8")
-        print(f"Changed ids -> {args.ids_out}")
-    print("These documents now need re-embedding: their semantic_vector still "
-          "describes the old text.")
+        args.ids_out.write_text("\n".join(reindex) + "\n", encoding="utf-8")
+        print(f"Re-embed ids -> {args.ids_out}")
+    if reindex:
+        print(f"{len(reindex)} document(s) had their embedding input "
+              f"(semantic_english_hint_source) corrected and need re-embedding. The "
+              f"rest were corrected past the hint cutoff, so their vectors never saw "
+              f"the old wording.")
+    else:
+        print("No embedding input changed; no re-embedding needed.")
     return 0
 
 

--- a/scripts/ops/apply_reported_corrections.py
+++ b/scripts/ops/apply_reported_corrections.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Apply reader-reported text corrections to hadith documents in Elasticsearch.
+
+Reads reported_corrections.json alongside this script, where each entry names the documents
+to touch, the field to edit, and exact (old, new) string pairs. A replacement is
+only applied when its `old` string is found verbatim, so a document that has already
+been corrected -- or that never matched -- is reported and skipped rather than
+guessed at.
+
+Dry run by default; pass --live to write.
+
+Usage:
+  python3 scripts/ops/apply_reported_corrections.py
+  python3 scripts/ops/apply_reported_corrections.py --live
+  python3 scripts/ops/apply_reported_corrections.py --live --es-host http://prod:9200
+"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+CORRECTIONS_JSON = Path(__file__).resolve().with_name("reported_corrections.json")
+
+
+def es_request(es_host, method, path, payload=None, timeout=60):
+    url = f"{es_host.rstrip('/')}/{path.lstrip('/')}"
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"{method} {path} -> {exc.code}: {exc.read().decode('utf-8')[:400]}") from exc
+    return json.loads(body) if body.strip() else {}
+
+
+def fetch(es_host, index, ids):
+    docs = es_request(es_host, "POST", f"/{index}/_mget", {"ids": ids})["docs"]
+    return {d["_id"]: (d.get("_source") if d.get("found") else None) for d in docs}
+
+
+def plan_document(source, field, replacements):
+    """Return (new_value, applied, missing) for one document."""
+    original = source.get(field) or ""
+    value = original
+    applied, missing = [], []
+    for old, new in replacements:
+        # `new` is checked first: an append-style correction keeps `old` intact
+        # inside its own replacement, so testing `old` first would re-append on
+        # every run.
+        if new in value:
+            missing.append((old, "already applied"))
+        elif old in value:
+            value = value.replace(old, new)
+            applied.append(old)
+        else:
+            missing.append((old, "not found"))
+    return (value if value != original else None), applied, missing
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--es-host", default="http://localhost:9200")
+    parser.add_argument("--index", default="rewayaat_updated")
+    parser.add_argument("--corrections", type=Path, default=CORRECTIONS_JSON)
+    parser.add_argument("--live", action="store_true", help="write to Elasticsearch")
+    parser.add_argument("--ids-out", type=Path,
+                        help="write the changed ids here (feed to the embedding regen)")
+    args = parser.parse_args()
+
+    spec = json.loads(args.corrections.read_text(encoding="utf-8"))
+    entries = spec["corrections"]
+
+    wanted = sorted({i for e in entries for i in e["ids"]})
+    sources = fetch(args.es_host, args.index, wanted)
+
+    updates, skipped, problems = {}, [], []
+
+    for entry in entries:
+        for doc_id in entry["ids"]:
+            source = sources.get(doc_id)
+            if source is None:
+                problems.append((doc_id, "document not found"))
+                continue
+            new_value, applied, missing = plan_document(source, entry["field"], entry["replacements"])
+            for old, why in missing:
+                (skipped if why == "already applied" else problems).append(
+                    (doc_id, f"{why}: {old[:60]}"))
+            if new_value is not None:
+                updates[doc_id] = {"field": entry["field"], "value": new_value,
+                                   "kind": entry["kind"], "count": len(applied)}
+
+    for doc_id, info in sorted(updates.items()):
+        flag = "  <-- REVIEW" if info["kind"] == "rewrite" else ""
+        print(f"  {doc_id:46} {info['kind']:10} {info['count']} edit(s){flag}")
+
+    print(f"\n{len(updates)} document(s) to change, {len(skipped)} already correct, "
+          f"{len(problems)} problem(s)")
+    for doc_id, why in problems:
+        print(f"  PROBLEM {doc_id}: {why}")
+
+    for item in spec.get("deferred", []):
+        print(f"  DEFERRED {item['id']}: {item['reason']}")
+
+    if not updates:
+        return 0
+    if not args.live:
+        print("\nDry run. Re-run with --live to write.")
+        return 0
+
+    lines = []
+    for doc_id, info in updates.items():
+        lines.append(json.dumps({"update": {"_id": doc_id, "_index": args.index}}))
+        lines.append(json.dumps({"doc": {info["field"]: info["value"]}}, ensure_ascii=False))
+    payload = ("\n".join(lines) + "\n").encode("utf-8")
+
+    url = f"{args.es_host.rstrip('/')}/_bulk?refresh=true"
+    req = urllib.request.Request(url, data=payload, method="POST",
+                                 headers={"Content-Type": "application/x-ndjson"})
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        result = json.loads(resp.read().decode("utf-8"))
+
+    if result.get("errors"):
+        for item in result["items"]:
+            err = item.get("update", {}).get("error")
+            if err:
+                print(f"  ERROR {item['update']['_id']}: {err.get('reason')}")
+        return 1
+
+    print(f"\nWrote {len(updates)} document(s) to {args.index} on {args.es_host}.")
+    if args.ids_out:
+        args.ids_out.write_text("\n".join(sorted(updates)) + "\n", encoding="utf-8")
+        print(f"Changed ids -> {args.ids_out}")
+    print("These documents now need re-embedding: their semantic_vector still "
+          "describes the old text.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/reported_corrections.json
+++ b/scripts/ops/reported_corrections.json
@@ -1,0 +1,334 @@
+{
+ "description": "Corrections confirmed against reader reports emailed to rewayaat.org@gmail.com, Jun-Sep 2026. Each replacement was verified against the Arabic in the same document.",
+ "deferred": [
+  {
+   "id": "Maani-al-Akhbar-Saduq:276",
+   "reason": "The ARABIC is truncated (ends at the verse توبوا إلى الله توبة نصوحا); the English already carries the answer. Restoring it needs a printed edition - not derivable from anything in the corpus."
+  },
+  {
+   "id": "Kitab-al-Zuhd-Ahwazi:85",
+   "reason": "Arabic is a byte-identical copy of Zuhd:84. The true Arabic for the 'Gate of Goodness' narration exists nowhere in the corpus. Needs a printed edition."
+  }
+ ],
+ "corrections": [
+  {
+   "ids": [
+    "Al-Kafi-Volume-3-Kulayni:261"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "Tour water on it twice",
+     "Pour water on it twice"
+    ]
+   ],
+   "kind": "typo",
+   "note": "Reporter gave the correction outright.",
+   "reported_in": "19f6eae41de35fd1 2026-07-17"
+  },
+  {
+   "ids": [
+    "Al-Kafi-Volume-5-Kulayni:501"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "above fair piece",
+     "above fair price"
+    ]
+   ],
+   "kind": "typo",
+   "note": "AR غبن. Reporter noted the wider sense is 'cheating'; only the typo is applied.",
+   "reported_in": "19f363dea86ba07e 2026-07-06"
+  },
+  {
+   "ids": [
+    "Al-Kafi-Volume-2-Kulayni:1519"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "from morning to evening",
+     "from morning to night"
+    ]
+   ],
+   "kind": "term",
+   "note": "AR أُجِّلَ مِنْ غُدْوَةٍ إِلَى اللَّيْلِ — layl is night.",
+   "reported_in": "19eac8dfe69b1f1f 2026-06-09"
+  },
+  {
+   "ids": [
+    "Al-Kafi-Volume-2-Kulayni:2232"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "the Most Holy, grant you forgiveness.",
+     "the Most Holy, have mercy on you."
+    ]
+   ],
+   "kind": "term",
+   "note": "AR يَرْحَمُكَ اللهُ = mercy. Only the final sentence is wrong; the earlier one is correct.",
+   "reported_in": "19f58edfb50568dc 2026-07-13"
+  },
+  {
+   "ids": [
+    "Al-Kafi-Volume-3-Kulayni:863"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "a person who is suffering sorrow and grief due to the death of his son,",
+     "a person who is afflicted,"
+    ]
+   ],
+   "kind": "insertion",
+   "note": "AR مَنْ عَزَّى مُصَاباً — no son in the Arabic; the insertion narrows the ruling.",
+   "reported_in": "19ed40e9b9c87793 2026-06-17"
+  },
+  {
+   "ids": [
+    "Al-Kafi-Volume-1-Kulayni:1441"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "Lord, my al-Khums was paid.",
+     "Lord, my khums!"
+    ]
+   ],
+   "kind": "insertion",
+   "note": "AR يَا رَبِّ خُمُسِي is a bare claim; 'was paid' inverts who is owed.",
+   "reported_in": "19fa72d351f5965c 2026-07-28"
+  },
+  {
+   "ids": [
+    "Al-Kafi-Volume-3-Kulayni:288"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "If a dog pollutes your clothes",
+     "If a dog touches your clothes"
+    ],
+    [
+     "just pour water on your clothes",
+     "just sprinkle water on your clothes"
+    ]
+   ],
+   "kind": "term",
+   "note": "AR مسّ = contact (the ruling turns on it); انضحه = sprinkle, not pour.",
+   "reported_in": "19fa4c47b0ab80ab 2026-07-27"
+  },
+  {
+   "ids": [
+    "Al-Kafi-Volume-6-Kulayni:1095"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "a vein called ‘Isha’",
+     "a vein called al-‘Asha’"
+    ]
+   ],
+   "kind": "term",
+   "note": "AR العَشاء = supper. 'Isha' turns it into the night prayer; the narration is about skipping dinner.",
+   "reported_in": "1a01a9fa0e88d103 2026-08-19"
+  },
+  {
+   "ids": [
+    "Nahj-al-Balagha-Radi:1973"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "so much so that sometimes death results from effort.",
+     "so much so that sometimes death lies in the very contrivance."
+    ]
+   ],
+   "kind": "term",
+   "note": "AR التدبير = deliberate planning; the aphorism is that the scheme becomes the undoing.",
+   "reported_in": "1a088c7846c6fbf0 2026-09-10"
+  },
+  {
+   "ids": [
+    "Thawab-al-Amal-wa-iqab-al-Amal-Saduq:401"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "One who recites it on Friday eve",
+     "One who recites Surah al-Sajdah on Friday eve"
+    ]
+   ],
+   "kind": "omission",
+   "note": "AR names سُورَةَ السَّجْدَةِ; the English dropped it.",
+   "reported_in": "1a0683675f6e09fe 2026-09-03"
+  },
+  {
+   "ids": [
+    "Thawab-al-Amal-wa-iqab-al-Amal-Saduq:521"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "and he will get the reward of giving Sadaqah.",
+     "and he will get the reward of giving Sadaqah until it is returned to him."
+    ]
+   ],
+   "kind": "omission",
+   "note": "AR حَتَّى يَرْجِعَ إِلَيْهِ — the reward runs only while the loan is outstanding.",
+   "reported_in": "1a068493b15b0116 2026-09-03"
+  },
+  {
+   "ids": [
+    "Thawab-al-Amal-wa-iqab-al-Amal-Saduq:589"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "salutations  on  the  Holy  Prophet  (s.a.w.s.)",
+     "salutations  on  the  Holy  Prophet  (s.a.w.s.)  and  his  progeny"
+    ]
+   ],
+   "kind": "omission",
+   "note": "AR الصَّلَاةَ عَلَى النَّبِيِّ وَآلِهِ — 'wa alihi' dropped. (Source text has double spaces; matched verbatim.)",
+   "reported_in": "19f7518516be2118 2026-07-18"
+  },
+  {
+   "ids": [
+    "Thawab-al-Amal-wa-iqab-al-Amal-Saduq:765"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "will be awarded a fine dress to be worn on the Day of Judgment.",
+     "will be clothed at the Mawqif with a robe by which he is consoled."
+    ]
+   ],
+   "kind": "omission",
+   "note": "AR كُسِيَ فِي الْمَوْقِفِ حُلَّةً يُجْبَرُ بِهَا — reporter quoted the dropped words verbatim.",
+   "reported_in": "19f75206ef1d0bc1 2026-07-18"
+  },
+  {
+   "ids": [
+    "Man-La-Yahduruh-al-Faqih-Volume-4-Saduq:455"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "Imam (as) also said: \"Whoever bequeaths one-third without leaving anything behind has gone to excess.\"",
+     "Imam (as) also said: \"Whoever bequeaths one-third has not left [anything behind].\""
+    ]
+   ],
+   "kind": "insertion",
+   "note": "'has gone to excess' has no counterpart in the Arabic. NB the AR (فَلَمْ يَتَّرِكْ) looks damaged in the source too — check a printed edition.",
+   "reported_in": "19f5ed98a5c47536 2026-07-14"
+  },
+  {
+   "ids": [
+    "Man-La-Yahduruh-al-Faqih-Volume-1-Saduq:567"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "He has sent them wind after a calm, for without it, no one would bury a loved one;",
+     "He has cast upon them the odour after the soul departs, for without it, no one would bury a loved one;"
+    ],
+    [
+     "and He has put sustenance in this grain, for without it, kings would hoard it as they hoard gold and silver.",
+     "and He has set the creature upon this grain, for without it, kings would hoard it as they hoard gold and silver."
+    ]
+   ],
+   "kind": "term",
+   "note": "AR الرِّيحَ بَعْدَ الرُّوحِ (rih/ruh confused) and الدَّابَّةَ ('creature', not 'sustenance'). As translated neither clause explained its own 'for without it'.",
+   "reported_in": "19f9262c91baf349 2026-07-24"
+  },
+  {
+   "ids": [
+    "Kitab-al-Mumin-Ahwazi:53"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "and that is the meaning of Allah's words: And Allah multiplies for whom He pleases. [Holy Quran 2/261]",
+     "and that is the meaning of Allah's words: The parable of those who spend their wealth in the way of Allah is as the parable of a grain that grows seven ears, in every ear a hundred grains. And Allah multiplies for whom He pleases, and Allah is All-Encompassing, All-Knowing. [Holy Quran 2/261]"
+    ]
+   ],
+   "kind": "omission",
+   "note": "The verse quoted in the document's own Arabic runs the full length; the English carried only the last clause and dropped وَاللَّهُ وَاسِعٌ عَلِيمٌ.",
+   "reported_in": "1a0491d7c11a5de7 2026-08-28"
+  },
+  {
+   "ids": [
+    "Kitab-al-Ghayba-Tusi:437"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "As soon as I said this, I saw the she-camel rise up to the sky along with the litter.",
+     "As soon as I said this, I saw the she-camel rise up to the sky along with the litter. And the man had gestured towards a man of brown complexion, whose colour was like gold, with a mark of prostration between his eyes."
+    ]
+   ],
+   "kind": "omission",
+   "note": "Renders the final AR sentence وكان الرجل أومأ إلى رجل به سمرة، وكان لونه الذهب، بين عينيه سجادة.",
+   "reported_in": "19eba790a13213f2 2026-06-12"
+  },
+  {
+   "ids": [
+    "Thawab-al-Amal-wa-iqab-al-Amal-Saduq:448"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "“One who recites Surah Abas and Takrim would remain under the shade of Allah and would remain safe from usurping others’ property. He would receive favor of Allah and go to Paradise. And it is not a big thing for Almighty Allah.”",
+     "“One who recites Surah ‘Abasa wa Tawalla and Idha al-Shamsu Kuwwirat will be beneath the wing of Allah among the gardens, and in the shade of Allah and His honour within His gardens; and that is no great matter for Allah, if Allah wills.”"
+    ]
+   ],
+   "kind": "rewrite",
+   "note": "REVIEW. Reporter flagged only the surah name (Takrim -> al-Takwir), but the rest of the English did not match the Arabic either. Full re-rendering of the matn.",
+   "reported_in": "19ec6e8897b0563d 2026-06-14"
+  },
+  {
+   "ids": [
+    "Thawab-al-Amal-wa-iqab-al-Amal-Saduq:869"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "“A virtuous person will be made to sit inside a grave and told that he will be punished with a hundred lashes. He will say that he does not have the strength to bear that punishment. The punishment will be reduced continuously on his insistence till it is brought to a single lash. He will be told that a single lash is the minimum possible. That person will ask the reason for the punishment. He would be told that one day he offered Salaat without Wuzu and passed by a poor man without helping him. The person will be given punishment of one lash and because of which his grave will become full of fire.”",
+     "“A man from among the virtuous was made to sit in his grave and was told that he would be given a hundred lashes. He said that he did not have the strength to bear it. They kept reducing it at his insistence until they came down to a single lash, and they said that a single lash was the least possible. He asked what they were lashing him for. They said: one day you prayed without ablution, and you passed by a weak man and did not help him. So they gave him one lash of the punishment of Allah, Mighty and Majestic, and his grave filled with fire.”"
+    ]
+   ],
+   "kind": "rewrite",
+   "note": "REVIEW. AR opens أُقْعِدَ رَجُلٌ مِنَ الْأَخْيَارِ — past passive. The whole narration had been tense-shifted to the future.",
+   "reported_in": "19fa1e70256d1af7 2026-07-27"
+  },
+  {
+   "ids": [
+    "Al-Amali-Saduq:134",
+    "Al-Amali-Saduq:133",
+    "Al-Amali-Saduq:255",
+    "Al-Amali-Saduq:436",
+    "Al-Amali-Saduq:731",
+    "Al-Amali-Saduq:889",
+    "Al-Amali-Saduq:1002",
+    "Al-Amali-Saduq:1003",
+    "Al-Amali-Saduq:1006",
+    "Al-Amali-Saduq:1027",
+    "Al-Amali-Saduq:1033",
+    "Al-Amali-Saduq:1082"
+   ],
+   "field": "english",
+   "replacements": [
+    [
+     "Thuhr",
+     "Dhuhr"
+    ]
+   ],
+   "kind": "style",
+   "note": "House style: Dhuhr 88 docs, Zuhr 31, Thuhr 12. All 12 Thuhr hits are the prayer name, all in Al-Amali. Reported on :134; normalised across the set.",
+   "reported_in": "19f72cfdea04c848 2026-07-18"
+  }
+ ]
+}

--- a/scripts/ops/reported_corrections.json
+++ b/scripts/ops/reported_corrections.json
@@ -330,5 +330,10 @@
    "note": "House style: Dhuhr 88 docs, Zuhr 31, Thuhr 12. All 12 Thuhr hits are the prayer name, all in Al-Amali. Reported on :134; normalised across the set.",
    "reported_in": "19f72cfdea04c848 2026-07-18"
   }
- ]
+ ],
+ "mirror_fields": {
+  "english": [
+   "semantic_english_hint_source"
+  ]
+ }
 }


### PR DESCRIPTION
Records the reader-reported translation corrections that were **already applied to production data** on 2026-09-10, so the script and its source of truth live on `master` instead of only on an unmerged branch.

**Changes nothing on the running site:** it only adds two files under `scripts/ops/`.

## What it is

- 51 reports emailed to rewayaat.org@gmail.com between June and September 2026, covering 49 narrations. Each claim was checked against the Arabic in the same document; 47 held up.
- `scripts/ops/reported_corrections.json` records the 20 confirmed corrections, across 31 documents:
  - typos
  - words in the Arabic that never reached the English
  - words in the English with no counterpart in the Arabic
  - mistranslated terms, such as al-ʿAshāʾ (supper) read as ʿIshāʾ (the night prayer)
- Two entries are marked `rewrite` for review: Thawab:448 and Thawab:869.
- Two confirmed defects are deferred until a printed edition can be checked: Maani:276 and Zuhd:85.
- `scripts/ops/apply_reported_corrections.py` applies the corrections. It also carries each one into the derived `semantic_english_hint_source` field, so that re-embedding picks up the corrected wording rather than regenerating the same vector from stale text.

Six of the 31 documents had a correction fall inside that embedding hint. They were re-embedded with the fine-tuned e5-large model and verified identical on local and production.

These are the two corpus commits from `feature/reported-corrections`, cherry-picked onto current `master` unchanged. The third commit on that branch, a k8s manifest fix, is left out: `master` already sets `REWAYAAT_INDEX` to `rewayaat_hadith`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUxkFWM8dQhwYyE9CRJW1A
